### PR TITLE
Bugfix: Left join to creators for in progress query

### DIFF
--- a/app/Queries/Media/InProgressQuery.php
+++ b/app/Queries/Media/InProgressQuery.php
@@ -17,7 +17,7 @@ class InProgressQuery
             ->join('media_types', 'media.media_type_id', '=', 'media_types.id')
             ->join('media_events as started_events', 'media.id', '=', 'started_events.media_id')
             ->join('media_event_types', 'started_events.media_event_type_id', '=', 'media_event_types.id')
-            ->join('creators', 'creators.id', '=', 'media.creator_id')
+            ->leftJoin('creators', 'creators.id', '=', 'media.creator_id')
             ->where('media_event_types.name', MediaEventTypeName::STARTED);
 
         $query->whereNotExists(function ($subQuery) {

--- a/tests/Feature/Queries/Media/InProgressQueryTest.php
+++ b/tests/Feature/Queries/Media/InProgressQueryTest.php
@@ -6,11 +6,11 @@ use App\Queries\Media\InProgressQuery;
 use Illuminate\Support\Carbon;
 
 test('example', function () {
-
     Media::factory()
         ->book()
         ->has(MediaEvent::factory()->started()->at(Carbon::parse('2024-12-29')), 'events')
-        ->create(['title' => 'In Progress Book']);
+        // Leave Creator ID null to validate left join from media to creators
+        ->create(['title' => 'In Progress Book', 'creator_id' => null]);
 
     Media::factory()
         ->album()


### PR DESCRIPTION
Noticed that a video game didn't show up as In Progress in prod. Realized it's because it doesn't have a creator listed. 