### PR TITLE
Use prose for entire note

### DIFF
--- a/resources/views/livewire/notes/show-note-page.blade.php
+++ b/resources/views/livewire/notes/show-note-page.blade.php
@@ -4,28 +4,26 @@
     {{ $this->description() }}
 </x-slot>
 
-<div>
-    @if ($note->title)
-        <x-type.page-title>{{ $note->title }}</x-type.page-title>
-    @endif
-
-    @if ($note->lead)
-        <p class="text-2xl mt-2">{{ $note->lead }}</p>
-    @endif
-
-    <p class="mt-2 text-gray-600">
+<article class="prose dark:prose-invert">
+    <p class="text-sm text-gray-600">
         {{ $note->publicationDate() }}
     </p>
 
-    @if ($note->content)
-        <div class="mt-4 prose">
-            {!! $note->content !!}
-        </div>
+    @if ($note->title)
+        <h1 class="font-serif">{{ $note->title }}</h1>
     @endif
 
-    <div class="mt-6">
+    @if ($note->lead)
+        <p class="lead">{{ $note->lead }}</p>
+    @endif
+
+    @if ($note->content)
+        {!! $note->content !!}
+    @endif
+
+    <p class="text-sm">
         <a href="{{ route("notes.index") }}" class="link" wire:navigate>
             Back to all notes
         </a>
-    </div>
-</div>
+    </p>
+</article>

--- a/tests/Feature/Http/Notes/ShowNoteTest.php
+++ b/tests/Feature/Http/Notes/ShowNoteTest.php
@@ -28,7 +28,7 @@ test('show', function () {
     ]);
     $response = $this->get('/notes/'.$note->slug);
     $response->assertSuccessful();
-    $response->assertSeeTextInOrder(['A cool post', 'You should read this', '2000', 'February', 'Captivating content']);
+    $response->assertSeeTextInOrder(['2000 February', 'A cool post', 'You should read this', 'Captivating content']);
 
     $response->assertSeeHtml('<title>A cool post</title>');
     $response->assertSeeHtml("<meta name=\"description\" content=\"You should read this\n\nBy David Harting.\nPublished on 2000 February 1\" />");


### PR DESCRIPTION
Instead of mixing prose underneath a custom title area, just use prose for the whole page.

Steve Schroger certainly came up with a better design than me.