### PR TITLE
Fix dashboard

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,4 +1,4 @@
-<x-layout.app $title="Dashboard - davidharting.com">
+<x-layout.app title="Dashboard - davidharting.com">
     <x-type.page-title class="mb-8">Dashboard</x-type.page-title>
 
     <ul>

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Models\User;
+use Tests\TestCase;
+
+test('redirects to login', function () {
+    /** @var TestCase $this */
+    $response = $this->get('/dashboard');
+    $response->assertStatus(302);
+});
+
+test('renders for logged in user', function () {
+    /** @var TestCase $this */
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get('/dashboard');
+    $response->assertOk();
+
+    $response->assertSeeTextInOrder(['Dashboard - davidharting.com', 'Profile']);
+    $response->assertSee("Log out");
+});

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -17,5 +17,5 @@ test('renders for logged in user', function () {
     $response->assertOk();
 
     $response->assertSeeTextInOrder(['Dashboard - davidharting.com', 'Profile']);
-    $response->assertSee("Log out");
+    $response->assertSee('Log out');
 });


### PR DESCRIPTION
When I introduced a title variable, I used it wrong!

When passing in string literals, you can just use the attribute name bare. Like `title="xyz"`.

When passing in a variable, you prepend with `:`. Like `:title="$xyz"`.

