### PR TITLE
Install nodejs into main image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,13 @@
-FROM node:22 AS frontend_builder
-
-COPY . /app
-WORKDIR /app
-
-RUN npm ci --no-audit
-RUN npm run build
-
-
-
 FROM dunglas/frankenphp:php8.2-bookworm
 
 
 RUN apt-get update \
     && apt-get install -y curl ca-certificates gnupg2 \
     && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-keyring.gpg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] https://apt.postgresql.org/pub/repos/apt jammy-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
-    && apt-get install -y unzip libnss3-tools procps postgresql-client-17 \
+    && apt-get install -y unzip libnss3-tools procps postgresql-client-17 nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 RUN install-php-extensions \
@@ -31,14 +22,14 @@ COPY docker-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 RUN mkdir -p /app/public/build
-COPY --from=frontend_builder /app/public/build/ /app/public/build/
-
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 COPY . /app
 
 RUN composer install --optimize-autoloader && php artisan optimize:clear
 
+RUN npm ci --no-audit
+RUN npm run build
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]
 CMD ["php", "artisan", "octane:frankenphp", "--caddyfile", "Caddyfile", "--https", "--http-redirect"]


### PR DESCRIPTION
This should significantly speed up build time.

By having the frontend builder be the main builder image, I consistently need to do full rebuilds of both images. this is because I copy the entire app over every time in the frontend builder, invalidating all layers in the subsequent image.

Installing OS dependencies and php extensions especially is quite slow.

I could optimize this further by only copying over composer lock file and package-lock.json files and installing from those before copying over the rest of the app