### PR TITLE
Upgrade to PHP 8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dunglas/frankenphp:php8.2-bookworm
+FROM dunglas/frankenphp:php8.3-bookworm
 
 
 RUN apt-get update \


### PR DESCRIPTION
Some of my deps are only compatible with php 8.3 after upgrade. I didn't realize i was using 8.3 locally and 8.2 in docker container.