### PR TITLE
Admin improvements

### DIFF
--- a/app/Filament/Resources/MediaEventResource.php
+++ b/app/Filament/Resources/MediaEventResource.php
@@ -41,7 +41,7 @@ class MediaEventResource extends Resource
     {
         return $table
             ->defaultSort('occurred_at', 'desc')
-            ->defaultPaginationPageOption(50)
+            ->defaultPaginationPageOption(10)
             ->columns([
                 Tables\Columns\TextColumn::make('mediaEventType.name')
                     ->sortable(),

--- a/app/Filament/Resources/MediaResource.php
+++ b/app/Filament/Resources/MediaResource.php
@@ -47,7 +47,7 @@ class MediaResource extends Resource
     {
         return $table
             ->defaultSort('updated_at', 'desc')
-            ->defaultPaginationPageOption(50)
+            ->defaultPaginationPageOption(10)
             ->columns([
                 Tables\Columns\TextColumn::make('created_at')
                     ->dateTime()

--- a/app/Filament/Resources/NoteResource.php
+++ b/app/Filament/Resources/NoteResource.php
@@ -36,6 +36,7 @@ class NoteResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
+            ->defaultSort('updated_at', 'desc')
             ->columns([
                 Tables\Columns\TextColumn::make('slug'),
                 Tables\Columns\TextColumn::make('title')->lineClamp(50),

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -28,7 +28,7 @@ class AdminPanelProvider extends PanelProvider
             ->path('admin')
             ->login()
             ->colors([
-                'primary' => Color::Amber,
+                'primary' => Color::Emerald,
             ])
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')

--- a/app/Queries/Media/BacklogQuery.php
+++ b/app/Queries/Media/BacklogQuery.php
@@ -21,6 +21,7 @@ class BacklogQuery
             ->leftJoin('media_events', 'media_events.media_id', '=', 'media.id')
 
             ->select(
+                'media.id as id',
                 'media.title as title',
                 'creators.name as creator',
                 'media_types.name as type',

--- a/app/Queries/Media/InProgressQuery.php
+++ b/app/Queries/Media/InProgressQuery.php
@@ -30,6 +30,7 @@ class InProgressQuery
         });
 
         $query->select(
+            'media.id as id',
             'media.title as title',
             'creators.name as creator',
             'media_types.name as type',

--- a/app/Queries/Media/LogbookQuery.php
+++ b/app/Queries/Media/LogbookQuery.php
@@ -26,6 +26,7 @@ class LogbookQuery
             ->leftJoin('creators', 'media.creator_id', '=', 'creators.id')
 
             ->select(
+                'media.id as id',
                 'media.title as title',
                 'creators.name as creator',
                 'media_types.name as type',

--- a/resources/views/components/media/item.blade.php
+++ b/resources/views/components/media/item.blade.php
@@ -8,4 +8,7 @@
         {{ $item->creator }}
     </div>
     <x-media.note :item="$item" />
+    @can('administrate')
+        <a class="link link-neutral text-xs text-gray-600" href="{{ route('filament.admin.resources.media.edit', $item->id) }}">Edit</a>
+    @endcan
 </div>

--- a/resources/views/components/media/item.blade.php
+++ b/resources/views/components/media/item.blade.php
@@ -8,7 +8,12 @@
         {{ $item->creator }}
     </div>
     <x-media.note :item="$item" />
-    @can('administrate')
-        <a class="link link-neutral text-xs text-gray-600" href="{{ route('filament.admin.resources.media.edit', $item->id) }}">Edit</a>
+    @can("administrate")
+        <a
+            class="link link-neutral text-xs text-gray-600"
+            href="{{ route("filament.admin.resources.media.edit", $item->id) }}"
+        >
+            Edit
+        </a>
     @endcan
 </div>

--- a/tests/Feature/Http/Filament/Media/EditMediaTest.php
+++ b/tests/Feature/Http/Filament/Media/EditMediaTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\Media;
+use App\Models\User;
+use Tests\TestCase;
+use League\HTMLToMarkdown\HtmlConverter;
+
+
+test('anonymous user not allowed', function () {
+    /** @var TestCase $this */
+    $media = Media::factory()->create();
+
+    $response = $this->get(route('filament.admin.resources.media.edit', $media));
+
+    $response->assertRedirect(route('filament.admin.auth.login'));
+});
+
+test('regular user not allowed', function () {
+    /** @var TestCase $this */
+    $user = User::factory()->create();
+    $media = Media::factory()->create();
+
+    $response = $this->actingAs($user)->get(route('filament.admin.resources.media.edit', $media));
+
+    $response->assertStatus(403);
+});
+
+test('Visible to admin', function () {
+    /** @var TestCase $this */
+    $media = Media::factory()->create(['title' => 'The Hobbit']);
+    $user = User::factory()->admin()->create();
+
+    $response = $this->actingAs($user)->get(route('filament.admin.resources.media.edit', $media));
+
+    $response->assertStatus(200);
+    $response->assertSeeText('Edit Media');
+});

--- a/tests/Feature/Http/Filament/Media/EditMediaTest.php
+++ b/tests/Feature/Http/Filament/Media/EditMediaTest.php
@@ -3,8 +3,6 @@
 use App\Models\Media;
 use App\Models\User;
 use Tests\TestCase;
-use League\HTMLToMarkdown\HtmlConverter;
-
 
 test('anonymous user not allowed', function () {
     /** @var TestCase $this */

--- a/tests/Feature/Livewire/Media/MediaPageTest.php
+++ b/tests/Feature/Livewire/Media/MediaPageTest.php
@@ -4,6 +4,7 @@ use App\Livewire\Media\MediaPage;
 use App\Models\Creator;
 use App\Models\Media;
 use App\Models\MediaEvent;
+use App\Models\User;
 use Illuminate\Support\Carbon;
 use Livewire\Livewire;
 
@@ -104,6 +105,28 @@ describe('with data', function () {
             ->assertDontSee('Backlogged Album')
             ->assertDontSee('Backlogged Book')
             ->assertDontSee('Reading Book');
+    });
+
+
+    describe('admin edit link', function () {
+        test('guest user cannot set it', function () {
+            Livewire::test(MediaPage::class)
+                ->assertDontSee('Edit');
+        });
+
+        test("regular users cannot set it", function () {
+            $this->actingAs(User::factory(['is_admin' => false])->create());
+
+            Livewire::test(MediaPage::class)
+                ->assertDontSee('Edit');
+        });
+
+        test('admins can see it', function () {
+            $this->actingAs(User::factory(['is_admin' => true])->create());
+
+            Livewire::test(MediaPage::class)
+                ->assertSee('Edit');
+        });
     });
 
     // TODO: Test filtering

--- a/tests/Feature/Livewire/Media/MediaPageTest.php
+++ b/tests/Feature/Livewire/Media/MediaPageTest.php
@@ -107,14 +107,13 @@ describe('with data', function () {
             ->assertDontSee('Reading Book');
     });
 
-
     describe('admin edit link', function () {
         test('guest user cannot set it', function () {
             Livewire::test(MediaPage::class)
                 ->assertDontSee('Edit');
         });
 
-        test("regular users cannot set it", function () {
+        test('regular users cannot set it', function () {
             $this->actingAs(User::factory(['is_admin' => false])->create());
 
             Livewire::test(MediaPage::class)

--- a/tests/Feature/Queries/Media/BacklogQueryTest.php
+++ b/tests/Feature/Queries/Media/BacklogQueryTest.php
@@ -28,22 +28,25 @@ test('backlog query test', function () {
         ->create(['title' => 'Abandoned Media']);
 
     // Create additional media with no events
-    Media::factory(['created_at' => Carbon::parse('2023-01-08')])
+    $backlogBook = Media::factory(['created_at' => Carbon::parse('2023-01-08')])
         ->book()
         ->for(Creator::factory(['name' => 'Author 4']))
         ->create(['title' => 'Backlog Book']);
 
-    Media::factory(['created_at' => Carbon::parse('2023-01-05')])
+    $backlogMovie = Media::factory(['created_at' => Carbon::parse('2023-01-05')])
         ->movie()
         ->create(['title' => 'Backlog Movie']);
 
     $result = (new BacklogQuery)->execute();
 
     expect($result)->toHaveCount(2);
+
+    expect($result->first()->id)->toBe($backlogBook->id);
     expect($result->first()->title)->toBe('Backlog Book');
     expect($result->first()->creator)->toBe('Author 4');
     expect($result->first()->type)->toBe('book');
     expect(Carbon::parse($result->first()->occurred_at)->format('Y F d'))->toBe('2023 January 08');
 
     expect($result->last()->title)->toBe('Backlog Movie');
+    expect($result->last()->id)->toBe($backlogMovie->id);
 });

--- a/tests/Feature/Queries/Media/InProgressQueryTest.php
+++ b/tests/Feature/Queries/Media/InProgressQueryTest.php
@@ -6,7 +6,7 @@ use App\Queries\Media\InProgressQuery;
 use Illuminate\Support\Carbon;
 
 test('example', function () {
-    Media::factory()
+    $inProgressBook = Media::factory()
         ->book()
         ->has(MediaEvent::factory()->started()->at(Carbon::parse('2024-12-29')), 'events')
         // Leave Creator ID null to validate left join from media to creators
@@ -27,13 +27,17 @@ test('example', function () {
         ->game()
         ->create(['title' => 'Backlogged Game']);
 
-    Media::factory()
+    $inProgressTvShow = Media::factory()
         ->show()
         ->has(MediaEvent::factory()->started()->at(Carbon::parse('2025-01-01')), 'events')
         ->create(['title' => 'In Progress TV Show']);
 
     $result = (new InProgressQuery)->execute();
     $this->assertCount(2, $result);
+
     $this->assertEquals('In Progress TV Show', $result->first()->title);
+    $this->assertEquals($inProgressTvShow->id, $result->first()->id);
+
     $this->assertEquals('In Progress Book', $result->last()->title);
+    $this->assertEquals($inProgressBook->id, $result->last()->id);
 });

--- a/tests/Feature/Queries/Media/LogbookQueryTest.php
+++ b/tests/Feature/Queries/Media/LogbookQueryTest.php
@@ -8,7 +8,7 @@ use Tests\TestCase;
 
 test('1 item', function () {
     /** @var TestCase $this */
-    Media::factory()
+    $media = Media::factory()
         ->book()
         ->for(Creator::factory(['name' => 'J.R.R. Tolkien']))
         ->has(MediaEvent::factory()->finished()->state(['occurred_at' => '2023-02-07']), 'events')
@@ -21,6 +21,7 @@ test('1 item', function () {
     expect($result)->toHaveCount(1);
 
     $first = $result->first();
+    expect($first->id)->toBe($media->id);
     expect($first->title)->toBe('The Hobbit');
     expect($first->creator)->toBe('J.R.R. Tolkien');
     expect($first->type)->toBe('book');


### PR DESCRIPTION
- Default page size of 10 (instead of 50)
  - Filament slows down a lot at 50. Let's keep it snappy. 
- Sort by most recently updated for all resources.
  - Usually what I want to see.
- Link from media on main site edit in admin
  - So that I don't have to go to admin and then search
- Use emerald as admin site primary color
  - Just to spice things up

I haven't written any dingle-dang tests yet so I'll merge after that.
- [x] Make sure Edit link is only visible to admins
- [x] Update query tests to account for ID in media.