### PR TITLE
Fix 500 error when admins view Backlog and In Progress pages

### DIFF
--- a/resources/views/components/media/note.blade.php
+++ b/resources/views/components/media/note.blade.php
@@ -5,7 +5,7 @@
         </div>
     @endif
 
-    @if ($item->finished_comment)
+    @if (isset($item->finished_comment) && $item->finished_comment)
         <div class="text-xs text-gray-600">
             {{ trim($item->finished_comment) }}
         </div>

--- a/tests/Feature/Livewire/Media/MediaPageTest.php
+++ b/tests/Feature/Livewire/Media/MediaPageTest.php
@@ -72,6 +72,21 @@ describe('with data', function () {
             ->assertDontSee('Reading Book');
     });
 
+    test('Backlog as admin', function () {
+        $this->actingAs(User::factory(['is_admin' => true])->create());
+
+        Livewire::withQueryParams(['list' => 'backlog'])->test(MediaPage::class)
+            ->assertStatus(200)
+            ->assertSeeInOrder([
+                '2023 July 22',
+                'Backlogged Album',
+                'Artist One',
+                '2022 January 01',
+                'Backlogged Book',
+                'Author One',
+            ]);
+    });
+
     test('In Progress', function () {
         Livewire::withQueryParams(['list' => 'in-progress'])->test(MediaPage::class)
             ->assertStatus(200)
@@ -85,6 +100,18 @@ describe('with data', function () {
             ->assertDontSee('Watched Movie')
             ->assertDontSee('Listened Album')
             ->assertDontSee('Read Book');
+    });
+
+    test('In Progress as admin', function () {
+        $this->actingAs(User::factory(['is_admin' => true])->create());
+
+        Livewire::withQueryParams(['list' => 'in-progress'])->test(MediaPage::class)
+            ->assertStatus(200)
+            ->assertSeeInOrder([
+                '2024 December 29',
+                'Reading Book',
+                'Author Three',
+            ]);
     });
 
     test('Finished (default)', function () {


### PR DESCRIPTION
## Summary

Fixes a bug where admin users were getting 500 errors ("Undefined property: stdClass::$finished_comment") when viewing the Backlog and In Progress pages.

The issue was introduced in commit 3a65569 when `finished_comment` was added to the Logbook view. The `note.blade.php` template started accessing this field, but `BacklogQuery` and `InProgressQuery` don't select it (only `LogbookQuery` does).

The fix adds a safe property check using `isset()` in the template, and includes new test coverage for admin users viewing these pages.

## Test plan

- [x] Added two new tests: "Backlog as admin" and "In Progress as admin"
- [x] All 12 MediaPageTest tests pass
- [x] All media query tests pass (BacklogQuery, InProgressQuery, LogbookQuery)
- [x] Verified the fix handles missing properties gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)