### PR TITLE
Add horizontal padding to container for mobile spacing

### DIFF
--- a/resources/views/components/layout/app.blade.php
+++ b/resources/views/components/layout/app.blade.php
@@ -27,7 +27,7 @@
     </head>
 
     <body class="font-sans antialiased">
-        <div class="container mx-auto">
+        <div class="container mx-auto px-4">
             <main class="mt-8">
                 <div class="flex justify-between w-full">
                     <div class="flex justify-start space-x-8 mb-8">


### PR DESCRIPTION
## Summary
- Adds `px-4` class to the main container to provide horizontal padding on all screen sizes
- Fixes edge-to-edge layout on mobile devices and at breakpoint boundaries where the container's max-width equals the viewport width

## Test plan
- [ ] Test on mobile device (content should have breathing room from edges)
- [ ] Test at various breakpoint boundaries (639px, 767px, 1023px, etc.)
- [ ] Verify consistent spacing across all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)