### PR TITLE
Add proof-of-concept for server-side code highlighting

### DIFF
--- a/app/Models/NoteWithHighlighting.php
+++ b/app/Models/NoteWithHighlighting.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Models;
+
+use App\Services\MarkdownRenderer;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Spatie\Feed\Feedable;
+use Spatie\Feed\FeedItem;
+
+/**
+ * Example of how Note would look with server-side syntax highlighting.
+ *
+ * Changes from original Note.php:
+ * 1. Added MarkdownRenderer dependency injection or direct instantiation
+ * 2. Changed renderContent() to use the custom renderer instead of Str::markdown()
+ *
+ * This is a PROOF OF CONCEPT - you would modify the original Note.php, not create a new file.
+ */
+class NoteWithHighlighting extends Model implements Feedable
+{
+    use HasFactory;
+
+    protected $table = 'notes';
+
+    protected $fillable = [
+        'slug',
+        'title',
+        'lead',
+        'markdown_content',
+        'visible',
+        'published_at',
+    ];
+
+    protected $casts = [
+        'published_at' => 'datetime:Y-m-d H:i:s.uO',
+    ];
+
+    public function getRouteKeyName()
+    {
+        return 'slug';
+    }
+
+    public function publicationDate(): string
+    {
+        return $this->published_at->format('Y F j');
+    }
+
+    /**
+     * Render markdown content with syntax highlighting.
+     *
+     * Uses MarkdownRenderer service which integrates Tempest Highlight
+     * (or Spatie highlighter) with CommonMark for server-side code highlighting.
+     */
+    public function renderContent(): ?string
+    {
+        if (! $this->markdown_content) {
+            return null;
+        }
+
+        // Option 1: Direct instantiation (simple)
+        $renderer = new MarkdownRenderer();
+
+        return $renderer->render($this->markdown_content);
+
+        // Option 2: Use Laravel's container (better for testing/DI)
+        // return app(MarkdownRenderer::class)->render($this->markdown_content);
+    }
+
+    public function toFeedItem(): FeedItem
+    {
+        return FeedItem::create()
+            ->id($this->slug)
+            ->title($this->title ?? 'Untitled note')
+            ->summary($this->renderContent() ?? '')
+            ->updated($this->published_at)
+            ->link(route('notes.show', $this->slug))
+            ->authorName('David Harting')
+            ->authorEmail('connect@davidharting.com');
+    }
+}

--- a/app/Services/MarkdownRenderer.php
+++ b/app/Services/MarkdownRenderer.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Services;
+
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
+use League\CommonMark\Extension\CommonMark\Node\Block\IndentedCode;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Code;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\MarkdownConverter;
+use Tempest\Highlight\CommonMark\CodeBlockRenderer;
+use Tempest\Highlight\CommonMark\InlineCodeBlockRenderer;
+
+/**
+ * Renders markdown with server-side syntax highlighting using Tempest Highlight.
+ *
+ * Usage:
+ *   $renderer = new MarkdownRenderer();
+ *   $html = $renderer->render($markdown);
+ *
+ * Requires: composer require tempest/highlight:^1.0
+ *
+ * CSS: Include one of the themes from vendor/tempest/highlight/src/Themes/
+ * or use the InlineTheme for inline styles.
+ */
+class MarkdownRenderer
+{
+    private MarkdownConverter $converter;
+
+    public function __construct()
+    {
+        $environment = new Environment([
+            'html_input' => 'allow',
+            'allow_unsafe_links' => true,
+        ]);
+
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new GithubFlavoredMarkdownExtension());
+
+        // Register Tempest Highlight renderers
+        $environment->addRenderer(FencedCode::class, new CodeBlockRenderer(), 10);
+        $environment->addRenderer(IndentedCode::class, new CodeBlockRenderer(), 10);
+        $environment->addRenderer(Code::class, new InlineCodeBlockRenderer(), 10);
+
+        $this->converter = new MarkdownConverter($environment);
+    }
+
+    public function render(?string $markdown): ?string
+    {
+        if (! $markdown) {
+            return null;
+        }
+
+        return $this->converter->convert($markdown)->getContent();
+    }
+}

--- a/app/Services/MarkdownRendererSpatie.php
+++ b/app/Services/MarkdownRendererSpatie.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Services;
+
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
+use League\CommonMark\Extension\CommonMark\Node\Block\IndentedCode;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\MarkdownConverter;
+use Spatie\CommonMarkHighlighter\FencedCodeRenderer;
+use Spatie\CommonMarkHighlighter\IndentedCodeRenderer;
+
+/**
+ * Renders markdown with server-side syntax highlighting using Spatie/highlight.php.
+ *
+ * Usage:
+ *   $renderer = new MarkdownRendererSpatie();
+ *   $html = $renderer->render($markdown);
+ *
+ * Requires: composer require spatie/commonmark-highlighter
+ *
+ * CSS: Include a highlight.js theme, e.g.:
+ *   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+ *
+ * Or copy from vendor/scrivo/highlight.php/styles/
+ */
+class MarkdownRendererSpatie
+{
+    private MarkdownConverter $converter;
+
+    public function __construct()
+    {
+        // Common languages for auto-detection (optional, improves accuracy)
+        $languages = ['php', 'javascript', 'typescript', 'html', 'css', 'json', 'bash', 'sql'];
+
+        $environment = new Environment([
+            'html_input' => 'allow',
+            'allow_unsafe_links' => true,
+        ]);
+
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new GithubFlavoredMarkdownExtension());
+
+        // Register Spatie Highlighter renderers
+        $environment->addRenderer(FencedCode::class, new FencedCodeRenderer($languages), 10);
+        $environment->addRenderer(IndentedCode::class, new IndentedCodeRenderer($languages), 10);
+
+        $this->converter = new MarkdownConverter($environment);
+    }
+
+    public function render(?string $markdown): ?string
+    {
+        if (! $markdown) {
+            return null;
+        }
+
+        return $this->converter->convert($markdown)->getContent();
+    }
+}


### PR DESCRIPTION
This experiment explores two options for server-side syntax highlighting:

1. Tempest Highlight (MarkdownRenderer.php)
   - Modern, actively maintained
   - Requires tempest/highlight:^1.0 for PHP 8.3 compatibility
   - Built-in themes and CommonMark integration

2. Spatie CommonMark Highlighter (MarkdownRendererSpatie.php)
   - Uses scrivo/highlight.php (port of highlight.js)
   - Very stable, 36M+ installs
   - Uses highlight.js themes

NoteWithHighlighting.php shows how models would integrate with these
renderers, replacing Str::markdown() with the custom CommonMark setup.

https://claude.ai/code/session_01JwRs5J2uVs5wpvdwSEF7MS