### PR TITLE
Configure backup monitoring for private disk

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -255,7 +255,7 @@ return [
     'monitor_backups' => [
         [
             'name' => 'laravel-backup',
-            'disks' => [],
+            'disks' => [$privateDisk],
             'health_checks' => [
                 \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class => 1,
                 \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes::class => 5000,


### PR DESCRIPTION
## Summary
Updated the backup monitoring configuration to include the private disk in the monitored backups list.

## Changes
- Modified `config/backup.php` to add `$privateDisk` to the `disks` array in the `monitor_backups` configuration
- This enables backup health checks (maximum age and storage limits) to be applied to backups stored on the private disk

## Details
The `monitor_backups` configuration now explicitly monitors backups on the private disk, ensuring that backup age and storage size constraints are enforced. Previously, the `disks` array was empty, which meant no disks were being monitored for backup health.

https://claude.ai/code/session_01JQSBGwp7K5kiiTdjt1XfZt