### PR TITLE
Media Tracking Agent makes database updates for confirmed plans via sub-agent

### DIFF
--- a/.claude/rules/laravel-testing.md
+++ b/.claude/rules/laravel-testing.md
@@ -15,6 +15,26 @@ test('example', function () {
 });
 ```
 
+## Test naming and describe blocks
+
+Do not include the class under test in test string names — that is implied by the test file name.
+
+When a test file covers multiple methods, group tests into `describe` blocks named after the method being tested.
+
+```php
+// ❌ Bad
+test('SearchMedia returns found=false when no results', function () { ... });
+
+// ✓ Good
+describe('handle()', function () {
+    test('returns found=false when no results', function () { ... });
+});
+
+describe('schema()', function () {
+    test('enumerates valid media_type values', function () { ... });
+});
+```
+
 ## assertSee vs assertSeeText
 
 Use the appropriate assertion based on what you're testing:

--- a/app/Ai/Agents/MediaTrackingAgent.php
+++ b/app/Ai/Agents/MediaTrackingAgent.php
@@ -2,6 +2,7 @@
 
 namespace App\Ai\Agents;
 
+use App\Ai\Tools\MediaWritingAgentTool;
 use App\Ai\Tools\RequestConfirmation;
 use App\Ai\Tools\SearchMedia;
 use Laravel\Ai\Attributes\Model;
@@ -23,6 +24,7 @@ class MediaTrackingAgent implements Agent, Conversational, HasTools
 
     public function __construct(
         private ?RequestConfirmation $confirmationTool = null,
+        private ?MediaWritingAgentTool $writingTool = null,
     ) {}
 
     /**
@@ -106,6 +108,11 @@ class MediaTrackingAgent implements Agent, Conversational, HasTools
 
         Do not write anything like "Please confirm" or "Use the buttons to confirm". Just state the plan.
 
+
+        **Executing a Confirmed Plan**
+
+        When you receive "The user confirmed. Execute the plan.", call MediaWritingAgentTool with your plan text verbatim. Do not rephrase — pass the exact plan you stated in the confirmation message. After the tool returns, send its summary text to the user as your final message (prefix with ✓).
+
         PROMPT;
     }
 
@@ -116,10 +123,16 @@ class MediaTrackingAgent implements Agent, Conversational, HasTools
      */
     public function tools(): iterable
     {
-        return [
+        $tools = [
             new WebSearch,
             new SearchMedia,
             $this->confirmationTool ?? new RequestConfirmation,
         ];
+
+        if ($this->writingTool !== null) {
+            $tools[] = $this->writingTool;
+        }
+
+        return $tools;
     }
 }

--- a/app/Ai/Agents/MediaTrackingAgent.php
+++ b/app/Ai/Agents/MediaTrackingAgent.php
@@ -80,6 +80,8 @@ class MediaTrackingAgent implements Agent, Conversational, HasTools
         - If found and current_status is "finished": David has already finished it.
         - If found and current_status is "abandoned": David previously abandoned it.
 
+        Supported event types are: started, finished, abandoned, and comment. Comment events do not change the media status — they attach a free-text note to a media item (e.g. a thought, recommendation, or reflection).
+
         Once you have identified the item and checked the library, confirm back concisely: title, year, primary creator, media type, and current library status.
 
 
@@ -105,6 +107,7 @@ class MediaTrackingAgent implements Agent, Conversational, HasTools
         - "I'll add <b>Ghostwritten</b> (1999) by David Mitchell — Book to your library. Sound good?"
         - "I'll log a <i>finished</i> event for <b>Dune</b> (1965) by Frank Herbert — Book. Sound good?"
         - "I'll add <b>Blood Meridian</b> (1985) by Cormac McCarthy — Book to your library and log a <i>started</i> event. Sound good?"
+        - "I'll log a <i>comment</i> on <b>Ace Attorney Investigations: Miles Edgeworth</b>: "I think Katie would like this". Sound good?"
 
         Do not write anything like "Please confirm" or "Use the buttons to confirm". Just state the plan.
 

--- a/app/Ai/Agents/MediaTrackingAgent.php
+++ b/app/Ai/Agents/MediaTrackingAgent.php
@@ -111,7 +111,9 @@ class MediaTrackingAgent implements Agent, Conversational, HasTools
 
         **Executing a Confirmed Plan**
 
-        When you receive "The user confirmed. Execute the plan.", call MediaWritingAgentTool with your plan text verbatim. Do not rephrase — pass the exact plan you stated in the confirmation message. After the tool returns, send its summary text to the user as your final message (prefix with ✓).
+        MediaWritingAgentTool may or may not be available depending on the context:
+        - If it is NOT available, you are in read-only planning mode. Identify media, check the library, and call RequestConfirmation — but do not attempt to write anything.
+        - If it IS available, the user has confirmed. When you receive "The user confirmed. Execute the plan.", call MediaWritingAgentTool with your plan text verbatim. Do not rephrase — pass the exact plan you stated in the confirmation message. After the tool returns, send its summary text to the user as your final message (prefix with ✓).
 
         PROMPT;
     }

--- a/app/Ai/Tools/CreateMedia.php
+++ b/app/Ai/Tools/CreateMedia.php
@@ -7,6 +7,7 @@ use App\Models\Creator;
 use App\Models\Media;
 use App\Models\MediaType;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\DB;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
 use Stringable;
@@ -17,10 +18,11 @@ class CreateMedia implements Tool
     {
         return <<<'TEXT'
             Find or create a media item in the library. Provide either creator_id (when the
-            creator was found via SearchMedia) or creator_name (when the creator is new —
-            the tool will create the creator automatically). Exactly one of creator_id or
-            creator_name must be provided. Returns the media record details and whether it
-            was newly created.
+            creator was found via SearchMedia) or creator_name (when the creator is new or
+            not yet known — the tool will double-check if it's already in the DB and if not,
+            create the creator automatically). Exactly one of creator_id or creator_name must
+            be provided. Returns the media record details and whether the media and/or creator
+            were newly created.
             TEXT;
     }
 
@@ -55,43 +57,49 @@ class CreateMedia implements Tool
             );
         }
 
-        $creator = $creatorId !== null
-            ? Creator::find($creatorId)
-            : Creator::firstOrCreate(['name' => $creatorName]);
-
-        if ($creator === null) {
-            return json_encode(
-                ['error' => "Creator with id {$creatorId} not found."],
-                JSON_THROW_ON_ERROR,
-            );
-        }
-
-        $mediaType = MediaType::where('name', $mediaTypeName)->sole();
-
         $title = (string) $request->string('title');
         $year = $request->integer('year') ?: null;
         $note = ((string) $request->string('note')) ?: null;
 
-        $media = Media::firstOrCreate(
-            [
-                'title' => $title,
-                'media_type_id' => $mediaType->id,
-                'creator_id' => $creator->id,
-            ],
-            [
-                'year' => $year,
-                'note' => $note,
-            ],
-        );
+        $result = DB::transaction(function () use ($creatorId, $creatorName, $mediaTypeName, $title, $year, $note) {
+            $creator = $creatorId !== null
+                ? Creator::find($creatorId)
+                : Creator::firstOrCreate(['name' => $creatorName]);
 
-        return json_encode([
-            'media_id' => $media->id,
-            'title' => $media->title,
-            'year' => $media->year,
-            'creator' => $creator->name,
-            'media_type' => $mediaTypeName->value,
-            'created' => $media->wasRecentlyCreated,
-        ], JSON_THROW_ON_ERROR);
+            if ($creator === null) {
+                return ['error' => "Creator with id {$creatorId} not found."];
+            }
+
+            $mediaType = MediaType::where('name', $mediaTypeName)->sole();
+
+            $media = Media::firstOrCreate(
+                [
+                    'title' => $title,
+                    'media_type_id' => $mediaType->id,
+                    'creator_id' => $creator->id,
+                ],
+                [
+                    'year' => $year,
+                    'note' => $note,
+                ],
+            );
+
+            return [
+                'media_id' => $media->id,
+                'title' => $media->title,
+                'year' => $media->year,
+                'creator' => $creator->name,
+                'creator_created' => $creator->wasRecentlyCreated,
+                'media_type' => $mediaTypeName->value,
+                'created' => $media->wasRecentlyCreated,
+            ];
+        });
+
+        if (isset($result['error'])) {
+            return json_encode($result, JSON_THROW_ON_ERROR);
+        }
+
+        return json_encode($result, JSON_THROW_ON_ERROR);
     }
 
     public function schema(JsonSchema $schema): array
@@ -104,12 +112,12 @@ class CreateMedia implements Tool
             'creator_id' => $schema->integer()
                 ->description('The creator\'s ID as returned by SearchMedia. Use when the creator already exists in the library.'),
             'creator_name' => $schema->string()
-                ->description('The creator\'s name. Use when the creator is new — the tool will call firstOrCreate on Creator.'),
+                ->description('The creator\'s name. Use when the creator is new or not yet known in the library — the tool will call firstOrCreate on Creator.'),
             'media_type' => $schema->string()->required()
                 ->enum(array_column(MediaTypeName::cases(), 'value'))
                 ->description('The type of media.'),
             'note' => $schema->string()
-                ->description('An optional personal note about the media item.'),
+                ->description('An optional note about the media item provided by the human user.'),
         ];
     }
 }

--- a/app/Ai/Tools/CreateMedia.php
+++ b/app/Ai/Tools/CreateMedia.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Ai\Tools;
+
+use App\Enum\MediaTypeName;
+use App\Models\Creator;
+use App\Models\Media;
+use App\Models\MediaType;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Stringable;
+
+class CreateMedia implements Tool
+{
+    public function description(): Stringable|string
+    {
+        return <<<'TEXT'
+            Find or create a media item in the library. Provide either creator_id (when the
+            creator was found via SearchMedia) or creator_name (when the creator is new —
+            the tool will create the creator automatically). Exactly one of creator_id or
+            creator_name must be provided. Returns the media record details and whether it
+            was newly created.
+            TEXT;
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        $creatorId = $request->integer('creator_id') ?: null;
+        $creatorName = ((string) $request->string('creator_name')) ?: null;
+
+        if ($creatorId === null && $creatorName === null) {
+            return json_encode(
+                ['error' => 'Exactly one of creator_id or creator_name must be provided. Neither was given.'],
+                JSON_THROW_ON_ERROR,
+            );
+        }
+
+        if ($creatorId !== null && $creatorName !== null) {
+            return json_encode(
+                ['error' => 'Exactly one of creator_id or creator_name must be provided. Both were given.'],
+                JSON_THROW_ON_ERROR,
+            );
+        }
+
+        $mediaTypeString = (string) $request->string('media_type');
+        $mediaTypeName = MediaTypeName::tryFrom(strtolower($mediaTypeString));
+
+        if ($mediaTypeName === null) {
+            $valid = implode(', ', array_column(MediaTypeName::cases(), 'value'));
+
+            return json_encode(
+                ['error' => "Invalid media_type \"{$mediaTypeString}\". Must be one of: {$valid}."],
+                JSON_THROW_ON_ERROR,
+            );
+        }
+
+        $creator = $creatorId !== null
+            ? Creator::find($creatorId)
+            : Creator::firstOrCreate(['name' => $creatorName]);
+
+        if ($creator === null) {
+            return json_encode(
+                ['error' => "Creator with id {$creatorId} not found."],
+                JSON_THROW_ON_ERROR,
+            );
+        }
+
+        $mediaType = MediaType::where('name', $mediaTypeName)->sole();
+
+        $title = (string) $request->string('title');
+        $year = $request->integer('year') ?: null;
+        $note = ((string) $request->string('note')) ?: null;
+
+        $media = Media::firstOrCreate(
+            [
+                'title' => $title,
+                'media_type_id' => $mediaType->id,
+                'creator_id' => $creator->id,
+            ],
+            [
+                'year' => $year,
+                'note' => $note,
+            ],
+        );
+
+        return json_encode([
+            'media_id' => $media->id,
+            'title' => $media->title,
+            'year' => $media->year,
+            'creator' => $creator->name,
+            'media_type' => $mediaTypeName->value,
+            'created' => $media->wasRecentlyCreated,
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'title' => $schema->string()->required()
+                ->description('The title of the media item.'),
+            'year' => $schema->integer()
+                ->description('The publication or release year (optional).'),
+            'creator_id' => $schema->integer()
+                ->description('The creator\'s ID as returned by SearchMedia. Use when the creator already exists in the library.'),
+            'creator_name' => $schema->string()
+                ->description('The creator\'s name. Use when the creator is new — the tool will call firstOrCreate on Creator.'),
+            'media_type' => $schema->string()->required()
+                ->enum(array_column(MediaTypeName::cases(), 'value'))
+                ->description('The type of media.'),
+            'note' => $schema->string()
+                ->description('An optional personal note about the media item.'),
+        ];
+    }
+}

--- a/app/Ai/Tools/CreateMedia.php
+++ b/app/Ai/Tools/CreateMedia.php
@@ -91,7 +91,7 @@ class CreateMedia implements Tool
                 'creator' => $creator->name,
                 'creator_created' => $creator->wasRecentlyCreated,
                 'media_type' => $mediaTypeName->value,
-                'created' => $media->wasRecentlyCreated,
+                'media_created' => $media->wasRecentlyCreated,
             ];
         });
 

--- a/app/Ai/Tools/CreateMediaEvent.php
+++ b/app/Ai/Tools/CreateMediaEvent.php
@@ -18,9 +18,9 @@ class CreateMediaEvent implements Tool
     {
         return <<<'TEXT'
             Log a media tracking event (started, finished, abandoned, or comment) for a
-            media item. The occurred_at date must be an absolute ISO 8601 datetime —
-            resolve any relative references ("yesterday", "last Saturday") before calling
-            this tool.
+            media item. occurred_at accepts any date string Carbon can parse — ISO 8601,
+            natural language ("yesterday", "last Saturday"), or a plain date ("2026-03-15").
+            If no specific time was mentioned, default to noon (12:00:00) of the relevant day.
             TEXT;
     }
 
@@ -77,7 +77,7 @@ class CreateMediaEvent implements Tool
                 ->enum(array_column(MediaEventTypeName::cases(), 'value'))
                 ->description('The type of event to log.'),
             'occurred_at' => $schema->string()->required()
-                ->description('The absolute ISO 8601 datetime when the event occurred. Resolve any relative dates before calling this tool.'),
+                ->description('When the event occurred. Accepts ISO 8601, plain dates, or natural language Carbon can parse. If no time was mentioned, use noon (12:00:00) of the relevant day, e.g. "2026-03-15T12:00:00".'),
             'comment' => $schema->string()
                 ->description('An optional comment for comment-type events or annotations.'),
         ];

--- a/app/Ai/Tools/CreateMediaEvent.php
+++ b/app/Ai/Tools/CreateMediaEvent.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Ai\Tools;
+
+use App\Enum\MediaEventTypeName;
+use App\Models\Media;
+use App\Models\MediaEvent;
+use App\Models\MediaEventType;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Carbon;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Stringable;
+
+class CreateMediaEvent implements Tool
+{
+    public function description(): Stringable|string
+    {
+        return <<<'TEXT'
+            Log a media tracking event (started, finished, abandoned, or comment) for a
+            media item. The occurred_at date must be an absolute ISO 8601 datetime —
+            resolve any relative references ("yesterday", "last Saturday") before calling
+            this tool.
+            TEXT;
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        $mediaId = $request->integer('media_id');
+        $media = Media::find($mediaId);
+
+        if ($media === null) {
+            return json_encode(
+                ['error' => "Media with id {$mediaId} not found."],
+                JSON_THROW_ON_ERROR,
+            );
+        }
+
+        $eventTypeString = (string) $request->string('event_type');
+        $eventTypeName = MediaEventTypeName::tryFrom(strtolower($eventTypeString));
+
+        if ($eventTypeName === null) {
+            $valid = implode(', ', array_column(MediaEventTypeName::cases(), 'value'));
+
+            return json_encode(
+                ['error' => "Invalid event_type \"{$eventTypeString}\". Must be one of: {$valid}."],
+                JSON_THROW_ON_ERROR,
+            );
+        }
+
+        $mediaEventType = MediaEventType::where('name', $eventTypeName)->sole();
+
+        $occurredAt = Carbon::parse((string) $request->string('occurred_at'));
+        $comment = ((string) $request->string('comment')) ?: null;
+
+        $event = MediaEvent::create([
+            'media_id' => $media->id,
+            'media_event_type_id' => $mediaEventType->id,
+            'occurred_at' => $occurredAt,
+            'comment' => $comment,
+        ]);
+
+        return json_encode([
+            'event_id' => $event->id,
+            'media_id' => $media->id,
+            'event_type' => $eventTypeName->value,
+            'occurred_at' => $event->occurred_at->toIso8601String(),
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'media_id' => $schema->integer()->required()
+                ->description('The ID of the media item to log the event for.'),
+            'event_type' => $schema->string()->required()
+                ->enum(array_column(MediaEventTypeName::cases(), 'value'))
+                ->description('The type of event to log.'),
+            'occurred_at' => $schema->string()->required()
+                ->description('The absolute ISO 8601 datetime when the event occurred. Resolve any relative dates before calling this tool.'),
+            'comment' => $schema->string()
+                ->description('An optional comment for comment-type events or annotations.'),
+        ];
+    }
+}

--- a/app/Ai/Tools/MediaWritingAgentTool.php
+++ b/app/Ai/Tools/MediaWritingAgentTool.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Ai\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\Log;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Stringable;
+
+use function Laravel\Ai\agent;
+
+class MediaWritingAgentTool implements Tool
+{
+    public function description(): Stringable|string
+    {
+        return 'Execute a confirmed media tracking plan. Call this after the user confirms, passing your exact plan text.';
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        $plan = (string) $request->string('plan');
+
+        Log::info('MediaWritingAgentTool called', ['plan' => $plan]);
+
+        $response = agent(
+            instructions: $this->workerInstructions(),
+            tools: [new SearchMedia, new CreateMedia, new CreateMediaEvent],
+        )->prompt($plan, provider: 'anthropic', model: 'claude-sonnet-4-6');
+
+        return $response->text;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'plan' => $schema->string()->required()
+                ->description('The confirmed plan, e.g. "Add The Hobbit (1937) by J.R.R. Tolkien — Book and log a started event."'),
+        ];
+    }
+
+    private function workerInstructions(): string
+    {
+        $today = now()->toDateString();
+
+        return <<<PROMPT
+        You execute a confirmed media tracking plan by calling the available DB tools.
+
+        Today's date is {$today}.
+
+        **Creator resolution**
+        Always call SearchMedia with the creator name first to get creator_id before calling CreateMedia.
+        Use partial/fuzzy matching (e.g. "JRR Tolkien" may match "J.R.R. Tolkien").
+        If found, pass creator_id to CreateMedia. If not found, pass creator_name — the tool will create the creator.
+
+        **Relative dates**
+        Resolve any relative date references ("last Saturday", "yesterday") to an absolute ISO 8601 datetime before calling CreateMediaEvent.
+
+        **Backlog only**
+        If the plan is to add to the library with no event, call CreateMedia only.
+
+        **Return value**
+        Return a concise plain-text summary of exactly what was written.
+        Example: "Added The Hobbit (1937) by J.R.R. Tolkien — Book. Logged a started event on March 27, 2026."
+        PROMPT;
+    }
+}

--- a/app/Ai/Tools/MediaWritingAgentTool.php
+++ b/app/Ai/Tools/MediaWritingAgentTool.php
@@ -31,7 +31,7 @@ class MediaWritingAgentTool implements Tool
         Log::info('MediaWritingAgentTool called', ['plan' => $plan]);
 
         $response = agent(
-            instructions: $this->workerInstructions(),
+            instructions: $this->instructions(),
             tools: [new SearchMedia, new CreateMedia, new CreateMediaEvent],
         )->prompt($plan, provider: 'anthropic', model: 'claude-sonnet-4-6');
 
@@ -46,7 +46,7 @@ class MediaWritingAgentTool implements Tool
         ];
     }
 
-    private function workerInstructions(): string
+    private function instructions(): string
     {
         $today = now()->toDateString();
 
@@ -60,11 +60,6 @@ class MediaWritingAgentTool implements Tool
         Use partial search — for example, to find J.R.R. Tolkien search for "Tolkien" and inspect the results.
         If a matching creator is found, pass creator_id to CreateMedia.
         If not found, pass creator_name — the tool will create the creator.
-
-        **Dates**
-        Resolve relative date references ("last Saturday", "yesterday") to a specific date.
-        If no time of day was mentioned by the user, use noon (12:00:00) of the relevant day,
-        e.g. "2026-03-15T12:00:00".
 
         **Backlog only**
         If the plan is to add to the library with no event, call CreateMedia only.

--- a/app/Ai/Tools/MediaWritingAgentTool.php
+++ b/app/Ai/Tools/MediaWritingAgentTool.php
@@ -21,6 +21,13 @@ class MediaWritingAgentTool implements Tool
     {
         $plan = (string) $request->string('plan');
 
+        if ($plan === '') {
+            return json_encode(
+                ['error' => 'plan must not be empty. Pass the exact plan text you stated in the confirmation message.'],
+                JSON_THROW_ON_ERROR,
+            );
+        }
+
         Log::info('MediaWritingAgentTool called', ['plan' => $plan]);
 
         $response = agent(
@@ -50,11 +57,14 @@ class MediaWritingAgentTool implements Tool
 
         **Creator resolution**
         Always call SearchMedia with the creator name first to get creator_id before calling CreateMedia.
-        Use partial/fuzzy matching (e.g. "JRR Tolkien" may match "J.R.R. Tolkien").
-        If found, pass creator_id to CreateMedia. If not found, pass creator_name — the tool will create the creator.
+        Use partial search — for example, to find J.R.R. Tolkien search for "Tolkien" and inspect the results.
+        If a matching creator is found, pass creator_id to CreateMedia.
+        If not found, pass creator_name — the tool will create the creator.
 
-        **Relative dates**
-        Resolve any relative date references ("last Saturday", "yesterday") to an absolute ISO 8601 datetime before calling CreateMediaEvent.
+        **Dates**
+        Resolve relative date references ("last Saturday", "yesterday") to a specific date.
+        If no time of day was mentioned by the user, use noon (12:00:00) of the relevant day,
+        e.g. "2026-03-15T12:00:00".
 
         **Backlog only**
         If the plan is to add to the library with no event, call CreateMedia only.

--- a/app/Ai/Tools/MediaWritingAgentTool.php
+++ b/app/Ai/Tools/MediaWritingAgentTool.php
@@ -19,9 +19,9 @@ class MediaWritingAgentTool implements Tool
 
     public function handle(Request $request): Stringable|string
     {
-        $plan =  $request->string('plan', '');
+        $plan = $request->string('plan', '');
 
-        if ($plan === '') {
+        if ($plan->isEmpty()) {
             return json_encode(
                 ['error' => 'plan must not be empty. Pass the exact plan text you stated in the confirmation message.'],
                 JSON_THROW_ON_ERROR,

--- a/app/Ai/Tools/MediaWritingAgentTool.php
+++ b/app/Ai/Tools/MediaWritingAgentTool.php
@@ -19,7 +19,7 @@ class MediaWritingAgentTool implements Tool
 
     public function handle(Request $request): Stringable|string
     {
-        $plan = (string) $request->string('plan');
+        $plan =  $request->string('plan', '');
 
         if ($plan === '') {
             return json_encode(

--- a/app/Models/MediaTrackingSummary.php
+++ b/app/Models/MediaTrackingSummary.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Carbon;
  * Read-only Eloquent model backed by the media_tracking_summary view.
  *
  * @property int $media_id
+ * @property int|null $creator_id
  * @property string $title
  * @property int|null $year
  * @property string $media_type

--- a/app/Queries/Media/SearchMediaQuery.php
+++ b/app/Queries/Media/SearchMediaQuery.php
@@ -36,6 +36,7 @@ class SearchMediaQuery
 
         return $query->get([
             'media_id',
+            'creator_id',
             'title',
             'year',
             'media_type',

--- a/app/Telegram/Conversations/TrackConversation.php
+++ b/app/Telegram/Conversations/TrackConversation.php
@@ -3,6 +3,7 @@
 namespace App\Telegram\Conversations;
 
 use App\Ai\Agents\MediaTrackingAgent;
+use App\Ai\Tools\MediaWritingAgentTool;
 use App\Ai\Tools\RequestConfirmation;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -67,7 +68,11 @@ class TrackConversation extends Conversation
         $bot->answerCallbackQuery();
 
         if ($bot->callbackQuery()?->data === 'confirm') {
-            $bot->sendMessage('✓ Done. (DB writes coming in next milestone)');
+            $writingTool = new MediaWritingAgentTool;
+            $agent = (new MediaTrackingAgent(writingTool: $writingTool))
+                ->continue($this->aiConversationId, $this->conversationUser());
+            $response = $agent->prompt('The user confirmed. Execute the plan.');
+            $bot->sendMessage($response->text, parse_mode: ParseMode::HTML);
         } else {
             $bot->sendMessage('Cancelled. Nothing was changed.');
         }

--- a/app/Telegram/Conversations/TrackConversation.php
+++ b/app/Telegram/Conversations/TrackConversation.php
@@ -66,8 +66,10 @@ class TrackConversation extends Conversation
         // We send the outcome as a chat message (rather than answerCallbackQuery text)
         // so that it's persistent in the conversation and easily assertable in tests.
         $bot->answerCallbackQuery();
+        $bot->editMessageReplyMarkup();
 
         if ($bot->callbackQuery()?->data === 'confirm') {
+            $bot->sendMessage('On it! I\'ll report back when it\'s done.');
             $writingTool = new MediaWritingAgentTool;
             $agent = (new MediaTrackingAgent(writingTool: $writingTool))
                 ->continue($this->aiConversationId, $this->conversationUser());

--- a/database/migrations/2026_03_28_023449_add_creator_id_to_media_tracking_summary_view.php
+++ b/database/migrations/2026_03_28_023449_add_creator_id_to_media_tracking_summary_view.php
@@ -1,0 +1,93 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement('DROP VIEW IF EXISTS media_tracking_summary');
+
+        DB::statement(<<<'SQL'
+            CREATE VIEW media_tracking_summary AS
+            SELECT
+                m.id        AS media_id,
+                m.creator_id,
+                m.title,
+                m.year,
+                mt.name     AS media_type,
+                c.name      AS creator,
+                COALESCE(
+                    (
+                        SELECT met.name
+                        FROM media_events me
+                        JOIN media_event_types met ON me.media_event_type_id = met.id
+                        WHERE me.media_id = m.id
+                          AND met.name != 'comment'
+                        ORDER BY me.occurred_at DESC
+                        LIMIT 1
+                    ),
+                    'backlog'
+                )           AS current_status,
+                agg.started_at,
+                agg.finished_at,
+                agg.abandoned_at
+            FROM media m
+            LEFT JOIN media_types mt ON m.media_type_id = mt.id
+            LEFT JOIN creators c ON m.creator_id = c.id
+            LEFT JOIN LATERAL (
+                SELECT
+                    -- ASC: we want the earliest start date, not the most recent restart
+                    MIN(me.occurred_at) FILTER (WHERE met.name = 'started')   AS started_at,
+                    MAX(me.occurred_at) FILTER (WHERE met.name = 'finished')  AS finished_at,
+                    MAX(me.occurred_at) FILTER (WHERE met.name = 'abandoned') AS abandoned_at
+                FROM media_events me
+                JOIN media_event_types met ON me.media_event_type_id = met.id
+                WHERE me.media_id = m.id
+            ) agg ON TRUE
+        SQL);
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP VIEW IF EXISTS media_tracking_summary');
+
+        DB::statement(<<<'SQL'
+            CREATE VIEW media_tracking_summary AS
+            SELECT
+                m.id        AS media_id,
+                m.title,
+                m.year,
+                mt.name     AS media_type,
+                c.name      AS creator,
+                COALESCE(
+                    (
+                        SELECT met.name
+                        FROM media_events me
+                        JOIN media_event_types met ON me.media_event_type_id = met.id
+                        WHERE me.media_id = m.id
+                          AND met.name != 'comment'
+                        ORDER BY me.occurred_at DESC
+                        LIMIT 1
+                    ),
+                    'backlog'
+                )           AS current_status,
+                agg.started_at,
+                agg.finished_at,
+                agg.abandoned_at
+            FROM media m
+            LEFT JOIN media_types mt ON m.media_type_id = mt.id
+            LEFT JOIN creators c ON m.creator_id = c.id
+            LEFT JOIN LATERAL (
+                SELECT
+                    MIN(me.occurred_at) FILTER (WHERE met.name = 'started')   AS started_at,
+                    MAX(me.occurred_at) FILTER (WHERE met.name = 'finished')  AS finished_at,
+                    MAX(me.occurred_at) FILTER (WHERE met.name = 'abandoned') AS abandoned_at
+                FROM media_events me
+                JOIN media_event_types met ON me.media_event_type_id = met.id
+                WHERE me.media_id = m.id
+            ) agg ON TRUE
+        SQL);
+    }
+};

--- a/database/migrations/2026_03_28_023449_add_creator_id_to_media_tracking_summary_view.php
+++ b/database/migrations/2026_03_28_023449_add_creator_id_to_media_tracking_summary_view.php
@@ -7,13 +7,10 @@ return new class extends Migration
 {
     public function up(): void
     {
-        DB::statement('DROP VIEW IF EXISTS media_tracking_summary');
-
         DB::statement(<<<'SQL'
-            CREATE VIEW media_tracking_summary AS
+            CREATE OR REPLACE VIEW media_tracking_summary AS
             SELECT
                 m.id        AS media_id,
-                m.creator_id,
                 m.title,
                 m.year,
                 mt.name     AS media_type,
@@ -32,7 +29,8 @@ return new class extends Migration
                 )           AS current_status,
                 agg.started_at,
                 agg.finished_at,
-                agg.abandoned_at
+                agg.abandoned_at,
+                m.creator_id
             FROM media m
             LEFT JOIN media_types mt ON m.media_type_id = mt.id
             LEFT JOIN creators c ON m.creator_id = c.id

--- a/tests/Feature/Ai/MediaTrackingAgentTest.php
+++ b/tests/Feature/Ai/MediaTrackingAgentTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Ai\Agents\MediaTrackingAgent;
+use App\Ai\Tools\MediaWritingAgentTool;
 use App\Ai\Tools\RequestConfirmation;
 use App\Ai\Tools\SearchMedia;
 use Illuminate\Foundation\Testing\TestCase;
@@ -56,5 +57,22 @@ describe('tools()', function () {
 
         $tools = collect($agent->tools());
         $this->assertTrue($tools->contains(fn ($tool) => $tool instanceof RequestConfirmation));
+    });
+
+    test('does not include MediaWritingAgentTool by default', function () {
+        /** @var TestCase $this */
+        $agent = new MediaTrackingAgent;
+
+        $tools = collect($agent->tools());
+        $this->assertFalse($tools->contains(fn ($tool) => $tool instanceof MediaWritingAgentTool));
+    });
+
+    test('includes injected MediaWritingAgentTool when provided', function () {
+        /** @var TestCase $this */
+        $writingTool = new MediaWritingAgentTool;
+        $agent = new MediaTrackingAgent(writingTool: $writingTool);
+
+        $tools = collect($agent->tools());
+        $this->assertTrue($tools->contains($writingTool));
     });
 });

--- a/tests/Feature/Ai/Tools/CreateMediaEventTest.php
+++ b/tests/Feature/Ai/Tools/CreateMediaEventTest.php
@@ -1,106 +1,110 @@
 <?php
 
 use App\Ai\Tools\CreateMediaEvent;
+use App\Enum\MediaEventTypeName;
 use App\Models\Media;
+use App\Models\MediaEvent;
+use App\Models\MediaEventType;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\TestCase;
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 use Laravel\Ai\Tools\Request;
 
-test('CreateMediaEvent creates event with occurred_at set to provided datetime', function () {
-    /** @var TestCase $this */
-    $media = Media::factory()->book()->create();
+describe('handle()', function () {
+    test('creates event with occurred_at set to provided datetime', function () {
+        /** @var TestCase $this */
+        $media = Media::factory()->book()->create();
 
-    $result = json_decode(
-        (new CreateMediaEvent)->handle(new Request([
+        $result = json_decode(
+            (new CreateMediaEvent)->handle(new Request([
+                'media_id' => $media->id,
+                'event_type' => 'finished',
+                'occurred_at' => '2026-03-15T10:00:00Z',
+            ])),
+            true,
+        );
+
+        $this->assertArrayHasKey('event_id', $result);
+        $this->assertSame($media->id, $result['media_id']);
+        $this->assertSame('finished', $result['event_type']);
+
+        // occurred_at must be the provided value, not now()
+        $event = MediaEvent::find($result['event_id']);
+        $this->assertTrue($event->occurred_at->isSameDay('2026-03-15'));
+    });
+
+    test('creates event with comment', function () {
+        /** @var TestCase $this */
+        $media = Media::factory()->book()->create();
+
+        $result = json_decode(
+            (new CreateMediaEvent)->handle(new Request([
+                'media_id' => $media->id,
+                'event_type' => 'comment',
+                'occurred_at' => '2026-03-15T10:00:00Z',
+                'comment' => 'Really enjoyed this.',
+            ])),
+            true,
+        );
+
+        $this->assertArrayHasKey('event_id', $result);
+        $this->assertDatabaseHas('media_events', [
             'media_id' => $media->id,
-            'event_type' => 'finished',
-            'occurred_at' => '2026-03-15T10:00:00Z',
-        ])),
-        true,
-    );
-
-    $this->assertArrayHasKey('event_id', $result);
-    $this->assertSame($media->id, $result['media_id']);
-    $this->assertSame('finished', $result['event_type']);
-
-    // occurred_at must be the provided value, not now()
-    $this->assertDatabaseHas('media_events', [
-        'media_id' => $media->id,
-    ]);
-
-    $event = \App\Models\MediaEvent::find($result['event_id']);
-    $this->assertTrue($event->occurred_at->isSameDay('2026-03-15'));
-});
-
-test('CreateMediaEvent creates event with comment', function () {
-    /** @var TestCase $this */
-    $media = Media::factory()->book()->create();
-
-    $result = json_decode(
-        (new CreateMediaEvent)->handle(new Request([
-            'media_id' => $media->id,
-            'event_type' => 'comment',
-            'occurred_at' => '2026-03-15T10:00:00Z',
             'comment' => 'Really enjoyed this.',
-        ])),
-        true,
-    );
+        ]);
+    });
 
-    $this->assertArrayHasKey('event_id', $result);
-    $this->assertDatabaseHas('media_events', [
-        'media_id' => $media->id,
-        'comment' => 'Really enjoyed this.',
-    ]);
-});
+    test('returns error when media_id not found', function () {
+        /** @var TestCase $this */
+        $result = json_decode(
+            (new CreateMediaEvent)->handle(new Request([
+                'media_id' => 99999,
+                'event_type' => 'finished',
+                'occurred_at' => '2026-03-15T10:00:00Z',
+            ])),
+            true,
+        );
 
-test('CreateMediaEvent returns error when media_id not found', function () {
-    /** @var TestCase $this */
-    $result = json_decode(
+        $this->assertArrayHasKey('error', $result);
+        $this->assertStringContainsString('99999', $result['error']);
+    });
+
+    test('sole() throws if MediaEventType is missing', function () {
+        /** @var TestCase $this */
+        $media = Media::factory()->book()->create();
+
+        // Delete the event type to simulate missing seed data
+        MediaEventType::where('name', MediaEventTypeName::STARTED)->delete();
+
+        $this->expectException(ModelNotFoundException::class);
+
         (new CreateMediaEvent)->handle(new Request([
-            'media_id' => 99999,
-            'event_type' => 'finished',
+            'media_id' => $media->id,
+            'event_type' => 'started',
             'occurred_at' => '2026-03-15T10:00:00Z',
-        ])),
-        true,
-    );
-
-    $this->assertArrayHasKey('error', $result);
-    $this->assertStringContainsString('99999', $result['error']);
+        ]));
+    });
 });
 
-test('CreateMediaEvent sole() throws if MediaEventType is missing', function () {
-    /** @var TestCase $this */
-    $media = Media::factory()->book()->create();
+describe('schema()', function () {
+    test('defines required fields', function () {
+        /** @var TestCase $this */
+        $fields = (new CreateMediaEvent)->schema(new JsonSchemaTypeFactory);
 
-    // Delete the event type to simulate missing seed data
-    \App\Models\MediaEventType::where('name', 'started')->delete();
+        $this->assertArrayHasKey('media_id', $fields);
+        $this->assertArrayHasKey('event_type', $fields);
+        $this->assertArrayHasKey('occurred_at', $fields);
+        $this->assertArrayHasKey('comment', $fields);
+    });
 
-    $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+    test('enumerates valid event_type values', function () {
+        /** @var TestCase $this */
+        $schema = (new CreateMediaEvent)->schema(new JsonSchemaTypeFactory);
+        $compiled = $schema['event_type']->toArray();
 
-    (new CreateMediaEvent)->handle(new Request([
-        'media_id' => $media->id,
-        'event_type' => 'started',
-        'occurred_at' => '2026-03-15T10:00:00Z',
-    ]));
-});
-
-test('CreateMediaEvent schema defines required fields', function () {
-    /** @var TestCase $this */
-    $fields = (new CreateMediaEvent)->schema(new JsonSchemaTypeFactory);
-
-    $this->assertArrayHasKey('media_id', $fields);
-    $this->assertArrayHasKey('event_type', $fields);
-    $this->assertArrayHasKey('occurred_at', $fields);
-    $this->assertArrayHasKey('comment', $fields);
-});
-
-test('CreateMediaEvent schema enumerates valid event_type values', function () {
-    /** @var TestCase $this */
-    $schema = (new CreateMediaEvent)->schema(new JsonSchemaTypeFactory);
-    $compiled = $schema['event_type']->toArray();
-
-    $this->assertEqualsCanonicalizing(
-        ['started', 'finished', 'abandoned', 'comment'],
-        $compiled['enum'],
-    );
+        $this->assertEqualsCanonicalizing(
+            ['started', 'finished', 'abandoned', 'comment'],
+            $compiled['enum'],
+        );
+    });
 });

--- a/tests/Feature/Ai/Tools/CreateMediaEventTest.php
+++ b/tests/Feature/Ai/Tools/CreateMediaEventTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use App\Ai\Tools\CreateMediaEvent;
+use App\Models\Media;
+use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Tools\Request;
+
+test('CreateMediaEvent creates event with occurred_at set to provided datetime', function () {
+    /** @var TestCase $this */
+    $media = Media::factory()->book()->create();
+
+    $result = json_decode(
+        (new CreateMediaEvent)->handle(new Request([
+            'media_id' => $media->id,
+            'event_type' => 'finished',
+            'occurred_at' => '2026-03-15T10:00:00Z',
+        ])),
+        true,
+    );
+
+    $this->assertArrayHasKey('event_id', $result);
+    $this->assertSame($media->id, $result['media_id']);
+    $this->assertSame('finished', $result['event_type']);
+
+    // occurred_at must be the provided value, not now()
+    $this->assertDatabaseHas('media_events', [
+        'media_id' => $media->id,
+    ]);
+
+    $event = \App\Models\MediaEvent::find($result['event_id']);
+    $this->assertTrue($event->occurred_at->isSameDay('2026-03-15'));
+});
+
+test('CreateMediaEvent creates event with comment', function () {
+    /** @var TestCase $this */
+    $media = Media::factory()->book()->create();
+
+    $result = json_decode(
+        (new CreateMediaEvent)->handle(new Request([
+            'media_id' => $media->id,
+            'event_type' => 'comment',
+            'occurred_at' => '2026-03-15T10:00:00Z',
+            'comment' => 'Really enjoyed this.',
+        ])),
+        true,
+    );
+
+    $this->assertArrayHasKey('event_id', $result);
+    $this->assertDatabaseHas('media_events', [
+        'media_id' => $media->id,
+        'comment' => 'Really enjoyed this.',
+    ]);
+});
+
+test('CreateMediaEvent returns error when media_id not found', function () {
+    /** @var TestCase $this */
+    $result = json_decode(
+        (new CreateMediaEvent)->handle(new Request([
+            'media_id' => 99999,
+            'event_type' => 'finished',
+            'occurred_at' => '2026-03-15T10:00:00Z',
+        ])),
+        true,
+    );
+
+    $this->assertArrayHasKey('error', $result);
+    $this->assertStringContainsString('99999', $result['error']);
+});
+
+test('CreateMediaEvent sole() throws if MediaEventType is missing', function () {
+    /** @var TestCase $this */
+    $media = Media::factory()->book()->create();
+
+    // Delete the event type to simulate missing seed data
+    \App\Models\MediaEventType::where('name', 'started')->delete();
+
+    $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    (new CreateMediaEvent)->handle(new Request([
+        'media_id' => $media->id,
+        'event_type' => 'started',
+        'occurred_at' => '2026-03-15T10:00:00Z',
+    ]));
+});
+
+test('CreateMediaEvent schema defines required fields', function () {
+    /** @var TestCase $this */
+    $fields = (new CreateMediaEvent)->schema(new JsonSchemaTypeFactory);
+
+    $this->assertArrayHasKey('media_id', $fields);
+    $this->assertArrayHasKey('event_type', $fields);
+    $this->assertArrayHasKey('occurred_at', $fields);
+    $this->assertArrayHasKey('comment', $fields);
+});
+
+test('CreateMediaEvent schema enumerates valid event_type values', function () {
+    /** @var TestCase $this */
+    $schema = (new CreateMediaEvent)->schema(new JsonSchemaTypeFactory);
+    $compiled = $schema['event_type']->toArray();
+
+    $this->assertEqualsCanonicalizing(
+        ['started', 'finished', 'abandoned', 'comment'],
+        $compiled['enum'],
+    );
+});

--- a/tests/Feature/Ai/Tools/CreateMediaTest.php
+++ b/tests/Feature/Ai/Tools/CreateMediaTest.php
@@ -20,6 +20,7 @@ test('CreateMedia creates media with a new creator by name', function () {
     );
 
     $this->assertTrue($result['created']);
+    $this->assertTrue($result['creator_created']);
     $this->assertSame('Dune', $result['title']);
     $this->assertSame(1965, $result['year']);
     $this->assertSame('Frank Herbert', $result['creator']);
@@ -43,6 +44,7 @@ test('CreateMedia creates media with an existing creator by id', function () {
     );
 
     $this->assertTrue($result['created']);
+    $this->assertFalse($result['creator_created']);
     $this->assertSame('Dune Messiah', $result['title']);
     $this->assertSame('Frank Herbert', $result['creator']);
     $this->assertDatabaseCount('creators', 1);
@@ -64,6 +66,24 @@ test('CreateMedia returns created=false when media already exists (firstOrCreate
 
     $this->assertFalse($result['created']);
     $this->assertDatabaseCount('media', 1);
+});
+
+test('CreateMedia returns creator_created=false when creator already exists and found by name', function () {
+    /** @var TestCase $this */
+    Creator::factory()->create(['name' => 'Frank Herbert']);
+
+    $result = json_decode(
+        (new CreateMedia)->handle(new Request([
+            'title' => 'Children of Dune',
+            'creator_name' => 'Frank Herbert',
+            'media_type' => 'book',
+        ])),
+        true,
+    );
+
+    $this->assertTrue($result['created']);
+    $this->assertFalse($result['creator_created']);
+    $this->assertDatabaseCount('creators', 1);
 });
 
 test('CreateMedia returns error JSON when neither creator_id nor creator_name provided', function () {

--- a/tests/Feature/Ai/Tools/CreateMediaTest.php
+++ b/tests/Feature/Ai/Tools/CreateMediaTest.php
@@ -7,150 +7,154 @@ use Illuminate\Foundation\Testing\TestCase;
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 use Laravel\Ai\Tools\Request;
 
-test('CreateMedia creates media with a new creator by name', function () {
-    /** @var TestCase $this */
-    $result = json_decode(
-        (new CreateMedia)->handle(new Request([
-            'title' => 'Dune',
-            'year' => 1965,
-            'creator_name' => 'Frank Herbert',
-            'media_type' => 'book',
-        ])),
-        true,
-    );
+describe('handle()', function () {
+    test('creates media with a new creator by name', function () {
+        /** @var TestCase $this */
+        $result = json_decode(
+            (new CreateMedia)->handle(new Request([
+                'title' => 'Dune',
+                'year' => 1965,
+                'creator_name' => 'Frank Herbert',
+                'media_type' => 'book',
+            ])),
+            true,
+        );
 
-    $this->assertTrue($result['created']);
-    $this->assertTrue($result['creator_created']);
-    $this->assertSame('Dune', $result['title']);
-    $this->assertSame(1965, $result['year']);
-    $this->assertSame('Frank Herbert', $result['creator']);
-    $this->assertSame('book', $result['media_type']);
-    $this->assertDatabaseHas('creators', ['name' => 'Frank Herbert']);
-    $this->assertDatabaseHas('media', ['title' => 'Dune']);
+        $this->assertTrue($result['media_created']);
+        $this->assertTrue($result['creator_created']);
+        $this->assertSame('Dune', $result['title']);
+        $this->assertSame(1965, $result['year']);
+        $this->assertSame('Frank Herbert', $result['creator']);
+        $this->assertSame('book', $result['media_type']);
+        $this->assertDatabaseHas('creators', ['name' => 'Frank Herbert']);
+        $this->assertDatabaseHas('media', ['title' => 'Dune']);
+    });
+
+    test('creates media with an existing creator by id', function () {
+        /** @var TestCase $this */
+        $creator = Creator::factory()->create(['name' => 'Frank Herbert']);
+
+        $result = json_decode(
+            (new CreateMedia)->handle(new Request([
+                'title' => 'Dune Messiah',
+                'year' => 1969,
+                'creator_id' => $creator->id,
+                'media_type' => 'book',
+            ])),
+            true,
+        );
+
+        $this->assertTrue($result['media_created']);
+        $this->assertFalse($result['creator_created']);
+        $this->assertSame('Dune Messiah', $result['title']);
+        $this->assertSame('Frank Herbert', $result['creator']);
+        $this->assertDatabaseCount('creators', 1);
+    });
+
+    test('returns media_created=false when media already exists (firstOrCreate)', function () {
+        /** @var TestCase $this */
+        $creator = Creator::factory()->create(['name' => 'Frank Herbert']);
+        Media::factory()->book()->create(['title' => 'Dune', 'creator_id' => $creator->id]);
+
+        $result = json_decode(
+            (new CreateMedia)->handle(new Request([
+                'title' => 'Dune',
+                'creator_id' => $creator->id,
+                'media_type' => 'book',
+            ])),
+            true,
+        );
+
+        $this->assertFalse($result['media_created']);
+        $this->assertDatabaseCount('media', 1);
+    });
+
+    test('returns creator_created=false when creator already exists and found by name', function () {
+        /** @var TestCase $this */
+        Creator::factory()->create(['name' => 'Frank Herbert']);
+
+        $result = json_decode(
+            (new CreateMedia)->handle(new Request([
+                'title' => 'Children of Dune',
+                'creator_name' => 'Frank Herbert',
+                'media_type' => 'book',
+            ])),
+            true,
+        );
+
+        $this->assertTrue($result['media_created']);
+        $this->assertFalse($result['creator_created']);
+        $this->assertDatabaseCount('creators', 1);
+    });
+
+    test('returns error JSON when neither creator_id nor creator_name provided', function () {
+        /** @var TestCase $this */
+        $result = json_decode(
+            (new CreateMedia)->handle(new Request([
+                'title' => 'Dune',
+                'media_type' => 'book',
+            ])),
+            true,
+        );
+
+        $this->assertArrayHasKey('error', $result);
+        $this->assertStringContainsStringIgnoringCase('creator', $result['error']);
+    });
+
+    test('returns error JSON when both creator_id and creator_name provided', function () {
+        /** @var TestCase $this */
+        $creator = Creator::factory()->create();
+
+        $result = json_decode(
+            (new CreateMedia)->handle(new Request([
+                'title' => 'Dune',
+                'media_type' => 'book',
+                'creator_id' => $creator->id,
+                'creator_name' => 'Frank Herbert',
+            ])),
+            true,
+        );
+
+        $this->assertArrayHasKey('error', $result);
+        $this->assertStringContainsStringIgnoringCase('creator', $result['error']);
+    });
+
+    test('stores note when provided', function () {
+        /** @var TestCase $this */
+        $result = json_decode(
+            (new CreateMedia)->handle(new Request([
+                'title' => 'Dune',
+                'creator_name' => 'Frank Herbert',
+                'media_type' => 'book',
+                'note' => 'A classic sci-fi epic.',
+            ])),
+            true,
+        );
+
+        $this->assertTrue($result['media_created']);
+        $this->assertDatabaseHas('media', ['title' => 'Dune', 'note' => 'A classic sci-fi epic.']);
+    });
 });
 
-test('CreateMedia creates media with an existing creator by id', function () {
-    /** @var TestCase $this */
-    $creator = Creator::factory()->create(['name' => 'Frank Herbert']);
+describe('schema()', function () {
+    test('defines required fields', function () {
+        /** @var TestCase $this */
+        $fields = (new CreateMedia)->schema(new JsonSchemaTypeFactory);
 
-    $result = json_decode(
-        (new CreateMedia)->handle(new Request([
-            'title' => 'Dune Messiah',
-            'year' => 1969,
-            'creator_id' => $creator->id,
-            'media_type' => 'book',
-        ])),
-        true,
-    );
+        $this->assertArrayHasKey('title', $fields);
+        $this->assertArrayHasKey('media_type', $fields);
+        $this->assertArrayHasKey('creator_id', $fields);
+        $this->assertArrayHasKey('creator_name', $fields);
+    });
 
-    $this->assertTrue($result['created']);
-    $this->assertFalse($result['creator_created']);
-    $this->assertSame('Dune Messiah', $result['title']);
-    $this->assertSame('Frank Herbert', $result['creator']);
-    $this->assertDatabaseCount('creators', 1);
-});
+    test('enumerates valid media_type values', function () {
+        /** @var TestCase $this */
+        $schema = (new CreateMedia)->schema(new JsonSchemaTypeFactory);
+        $compiled = $schema['media_type']->toArray();
 
-test('CreateMedia returns created=false when media already exists (firstOrCreate)', function () {
-    /** @var TestCase $this */
-    $creator = Creator::factory()->create(['name' => 'Frank Herbert']);
-    Media::factory()->book()->create(['title' => 'Dune', 'creator_id' => $creator->id]);
-
-    $result = json_decode(
-        (new CreateMedia)->handle(new Request([
-            'title' => 'Dune',
-            'creator_id' => $creator->id,
-            'media_type' => 'book',
-        ])),
-        true,
-    );
-
-    $this->assertFalse($result['created']);
-    $this->assertDatabaseCount('media', 1);
-});
-
-test('CreateMedia returns creator_created=false when creator already exists and found by name', function () {
-    /** @var TestCase $this */
-    Creator::factory()->create(['name' => 'Frank Herbert']);
-
-    $result = json_decode(
-        (new CreateMedia)->handle(new Request([
-            'title' => 'Children of Dune',
-            'creator_name' => 'Frank Herbert',
-            'media_type' => 'book',
-        ])),
-        true,
-    );
-
-    $this->assertTrue($result['created']);
-    $this->assertFalse($result['creator_created']);
-    $this->assertDatabaseCount('creators', 1);
-});
-
-test('CreateMedia returns error JSON when neither creator_id nor creator_name provided', function () {
-    /** @var TestCase $this */
-    $result = json_decode(
-        (new CreateMedia)->handle(new Request([
-            'title' => 'Dune',
-            'media_type' => 'book',
-        ])),
-        true,
-    );
-
-    $this->assertArrayHasKey('error', $result);
-    $this->assertStringContainsStringIgnoringCase('creator', $result['error']);
-});
-
-test('CreateMedia returns error JSON when both creator_id and creator_name provided', function () {
-    /** @var TestCase $this */
-    $creator = Creator::factory()->create();
-
-    $result = json_decode(
-        (new CreateMedia)->handle(new Request([
-            'title' => 'Dune',
-            'media_type' => 'book',
-            'creator_id' => $creator->id,
-            'creator_name' => 'Frank Herbert',
-        ])),
-        true,
-    );
-
-    $this->assertArrayHasKey('error', $result);
-    $this->assertStringContainsStringIgnoringCase('creator', $result['error']);
-});
-
-test('CreateMedia stores note when provided', function () {
-    /** @var TestCase $this */
-    $result = json_decode(
-        (new CreateMedia)->handle(new Request([
-            'title' => 'Dune',
-            'creator_name' => 'Frank Herbert',
-            'media_type' => 'book',
-            'note' => 'A classic sci-fi epic.',
-        ])),
-        true,
-    );
-
-    $this->assertTrue($result['created']);
-    $this->assertDatabaseHas('media', ['title' => 'Dune', 'note' => 'A classic sci-fi epic.']);
-});
-
-test('CreateMedia schema defines required fields', function () {
-    /** @var TestCase $this */
-    $fields = (new CreateMedia)->schema(new JsonSchemaTypeFactory);
-
-    $this->assertArrayHasKey('title', $fields);
-    $this->assertArrayHasKey('media_type', $fields);
-    $this->assertArrayHasKey('creator_id', $fields);
-    $this->assertArrayHasKey('creator_name', $fields);
-});
-
-test('CreateMedia schema enumerates valid media_type values', function () {
-    /** @var TestCase $this */
-    $schema = (new CreateMedia)->schema(new JsonSchemaTypeFactory);
-    $compiled = $schema['media_type']->toArray();
-
-    $this->assertEqualsCanonicalizing(
-        ['album', 'book', 'movie', 'tv show', 'video game'],
-        $compiled['enum'],
-    );
+        $this->assertEqualsCanonicalizing(
+            ['album', 'book', 'movie', 'tv show', 'video game'],
+            $compiled['enum'],
+        );
+    });
 });

--- a/tests/Feature/Ai/Tools/CreateMediaTest.php
+++ b/tests/Feature/Ai/Tools/CreateMediaTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use App\Ai\Tools\CreateMedia;
+use App\Models\Creator;
+use App\Models\Media;
+use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Tools\Request;
+
+test('CreateMedia creates media with a new creator by name', function () {
+    /** @var TestCase $this */
+    $result = json_decode(
+        (new CreateMedia)->handle(new Request([
+            'title' => 'Dune',
+            'year' => 1965,
+            'creator_name' => 'Frank Herbert',
+            'media_type' => 'book',
+        ])),
+        true,
+    );
+
+    $this->assertTrue($result['created']);
+    $this->assertSame('Dune', $result['title']);
+    $this->assertSame(1965, $result['year']);
+    $this->assertSame('Frank Herbert', $result['creator']);
+    $this->assertSame('book', $result['media_type']);
+    $this->assertDatabaseHas('creators', ['name' => 'Frank Herbert']);
+    $this->assertDatabaseHas('media', ['title' => 'Dune']);
+});
+
+test('CreateMedia creates media with an existing creator by id', function () {
+    /** @var TestCase $this */
+    $creator = Creator::factory()->create(['name' => 'Frank Herbert']);
+
+    $result = json_decode(
+        (new CreateMedia)->handle(new Request([
+            'title' => 'Dune Messiah',
+            'year' => 1969,
+            'creator_id' => $creator->id,
+            'media_type' => 'book',
+        ])),
+        true,
+    );
+
+    $this->assertTrue($result['created']);
+    $this->assertSame('Dune Messiah', $result['title']);
+    $this->assertSame('Frank Herbert', $result['creator']);
+    $this->assertDatabaseCount('creators', 1);
+});
+
+test('CreateMedia returns created=false when media already exists (firstOrCreate)', function () {
+    /** @var TestCase $this */
+    $creator = Creator::factory()->create(['name' => 'Frank Herbert']);
+    Media::factory()->book()->create(['title' => 'Dune', 'creator_id' => $creator->id]);
+
+    $result = json_decode(
+        (new CreateMedia)->handle(new Request([
+            'title' => 'Dune',
+            'creator_id' => $creator->id,
+            'media_type' => 'book',
+        ])),
+        true,
+    );
+
+    $this->assertFalse($result['created']);
+    $this->assertDatabaseCount('media', 1);
+});
+
+test('CreateMedia returns error JSON when neither creator_id nor creator_name provided', function () {
+    /** @var TestCase $this */
+    $result = json_decode(
+        (new CreateMedia)->handle(new Request([
+            'title' => 'Dune',
+            'media_type' => 'book',
+        ])),
+        true,
+    );
+
+    $this->assertArrayHasKey('error', $result);
+    $this->assertStringContainsStringIgnoringCase('creator', $result['error']);
+});
+
+test('CreateMedia returns error JSON when both creator_id and creator_name provided', function () {
+    /** @var TestCase $this */
+    $creator = Creator::factory()->create();
+
+    $result = json_decode(
+        (new CreateMedia)->handle(new Request([
+            'title' => 'Dune',
+            'media_type' => 'book',
+            'creator_id' => $creator->id,
+            'creator_name' => 'Frank Herbert',
+        ])),
+        true,
+    );
+
+    $this->assertArrayHasKey('error', $result);
+    $this->assertStringContainsStringIgnoringCase('creator', $result['error']);
+});
+
+test('CreateMedia stores note when provided', function () {
+    /** @var TestCase $this */
+    $result = json_decode(
+        (new CreateMedia)->handle(new Request([
+            'title' => 'Dune',
+            'creator_name' => 'Frank Herbert',
+            'media_type' => 'book',
+            'note' => 'A classic sci-fi epic.',
+        ])),
+        true,
+    );
+
+    $this->assertTrue($result['created']);
+    $this->assertDatabaseHas('media', ['title' => 'Dune', 'note' => 'A classic sci-fi epic.']);
+});
+
+test('CreateMedia schema defines required fields', function () {
+    /** @var TestCase $this */
+    $fields = (new CreateMedia)->schema(new JsonSchemaTypeFactory);
+
+    $this->assertArrayHasKey('title', $fields);
+    $this->assertArrayHasKey('media_type', $fields);
+    $this->assertArrayHasKey('creator_id', $fields);
+    $this->assertArrayHasKey('creator_name', $fields);
+});
+
+test('CreateMedia schema enumerates valid media_type values', function () {
+    /** @var TestCase $this */
+    $schema = (new CreateMedia)->schema(new JsonSchemaTypeFactory);
+    $compiled = $schema['media_type']->toArray();
+
+    $this->assertEqualsCanonicalizing(
+        ['album', 'book', 'movie', 'tv show', 'video game'],
+        $compiled['enum'],
+    );
+});

--- a/tests/Feature/Ai/Tools/MediaWritingAgentToolTest.php
+++ b/tests/Feature/Ai/Tools/MediaWritingAgentToolTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Ai\Tools\MediaWritingAgentTool;
+use Illuminate\Foundation\Testing\TestCase;
+use Laravel\Ai\Tools\Request;
+
+describe('handle()', function () {
+    test('returns error when plan is empty string', function () {
+        /** @var TestCase $this */
+        $result = json_decode(
+            (new MediaWritingAgentTool)->handle(new Request(['plan' => ''])),
+            true,
+        );
+
+        $this->assertArrayHasKey('error', $result);
+    });
+
+    test('returns error when plan is not provided', function () {
+        /** @var TestCase $this */
+        $result = json_decode(
+            (new MediaWritingAgentTool)->handle(new Request([])),
+            true,
+        );
+
+        $this->assertArrayHasKey('error', $result);
+    });
+});

--- a/tests/Feature/Ai/Tools/SearchMediaTest.php
+++ b/tests/Feature/Ai/Tools/SearchMediaTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Ai\Tools\SearchMedia;
+use App\Models\Creator;
 use App\Models\Media;
 use Illuminate\Foundation\Testing\TestCase;
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
@@ -73,6 +74,29 @@ test('SearchMedia returns JSON with found=true and results when media matches', 
     $this->assertCount(1, $result['results']);
     $this->assertSame($media->id, $result['results'][0]['media_id']);
     $this->assertSame('The Hobbit', $result['results'][0]['title']);
+});
+
+test('SearchMedia results include creator_id', function () {
+    /** @var TestCase $this */
+    $creator = Creator::factory()->create(['name' => 'Frank Herbert']);
+    Media::factory()->book()->create(['title' => 'Dune', 'creator_id' => $creator->id]);
+
+    $result = json_decode((new SearchMedia)->handle(new Request(['title' => 'Dune'])), true);
+
+    $this->assertTrue($result['found']);
+    $this->assertArrayHasKey('creator_id', $result['results'][0]);
+    $this->assertSame($creator->id, $result['results'][0]['creator_id']);
+});
+
+test('SearchMedia results include null creator_id when creator is not set', function () {
+    /** @var TestCase $this */
+    Media::factory()->book()->create(['title' => 'Unknown Origin', 'creator_id' => null]);
+
+    $result = json_decode((new SearchMedia)->handle(new Request(['title' => 'Unknown Origin'])), true);
+
+    $this->assertTrue($result['found']);
+    $this->assertArrayHasKey('creator_id', $result['results'][0]);
+    $this->assertNull($result['results'][0]['creator_id']);
 });
 
 test('SearchMedia media_type filter is case-insensitive', function () {

--- a/tests/Feature/Telegram/TrackConversationTest.php
+++ b/tests/Feature/Telegram/TrackConversationTest.php
@@ -1,7 +1,11 @@
 <?php
 
 use App\Ai\Agents\MediaTrackingAgent;
+use App\Ai\Tools\MediaWritingAgentTool;
 use App\Ai\Tools\RequestConfirmation;
+use App\Models\Creator;
+use App\Models\Media;
+use App\Models\MediaEvent;
 use Illuminate\Foundation\Testing\TestCase;
 use Laravel\Ai\Tools\Request;
 use SergiX44\Nutgram\Nutgram;
@@ -128,9 +132,12 @@ test('/track sends message with inline keyboard when agent calls RequestConfirma
         ->assertActiveConversation();
 });
 
-test('tapping Confirm ends the conversation with acknowledgement', function () {
+test('tapping Confirm calls MediaTrackingAgent with the confirmed plan and sends summary', function () {
     /** @var TestCase $this */
-    MediaTrackingAgent::fake(['Add "The Hobbit" (1937) by J.R.R. Tolkien — Book to your library.']);
+    MediaTrackingAgent::fake([
+        'I\'ll add <b>The Hobbit</b> (1937) by J.R.R. Tolkien — Book to your library. Sound good?',
+        '✓ Added The Hobbit (1937) by J.R.R. Tolkien — Book.',
+    ]);
     PreTriggeredConfirmation::bind();
 
     /** @var FakeNutgram $bot */
@@ -142,7 +149,7 @@ test('tapping Confirm ends the conversation with acknowledgement', function () {
 
     $bot->hearCallbackQueryData('confirm')
         ->reply()
-        ->assertReplyText('✓ Done. (DB writes coming in next milestone)', index: 1)
+        ->assertReplyText('✓ Added The Hobbit (1937) by J.R.R. Tolkien — Book.', index: 1)
         ->assertNoConversation();
 });
 
@@ -220,6 +227,27 @@ test('/track persists the conversation to the database', function () {
         'role' => 'assistant',
         'content' => 'Which Dune did you mean?',
     ]);
+});
+
+test('tapping Cancel ends the conversation and no DB rows are created', function () {
+    /** @var TestCase $this */
+    MediaTrackingAgent::fake(['I\'ll add <b>The Hobbit</b> (1937) by J.R.R. Tolkien — Book to your library. Sound good?']);
+    PreTriggeredConfirmation::bind();
+
+    /** @var FakeNutgram $bot */
+    $bot = app(Nutgram::class);
+    $bot->setCommonUser(davidUser());
+    $bot->willStartConversation();
+
+    $bot->hearText('/track Add The Hobbit')->reply();
+
+    $bot->hearCallbackQueryData('cancel')
+        ->reply()
+        ->assertReplyText('Cancelled. Nothing was changed.', index: 1)
+        ->assertNoConversation();
+
+    $this->assertDatabaseCount('media', 0);
+    $this->assertDatabaseCount('media_events', 0);
 });
 
 test('unauthorized user is rejected from /track', function () {

--- a/tests/Feature/Telegram/TrackConversationTest.php
+++ b/tests/Feature/Telegram/TrackConversationTest.php
@@ -1,11 +1,7 @@
 <?php
 
 use App\Ai\Agents\MediaTrackingAgent;
-use App\Ai\Tools\MediaWritingAgentTool;
 use App\Ai\Tools\RequestConfirmation;
-use App\Models\Creator;
-use App\Models\Media;
-use App\Models\MediaEvent;
 use Illuminate\Foundation\Testing\TestCase;
 use Laravel\Ai\Tools\Request;
 use SergiX44\Nutgram\Nutgram;
@@ -153,7 +149,7 @@ test('tapping Confirm calls MediaTrackingAgent with the confirmed plan and sends
         ->assertNoConversation();
 });
 
-test('tapping Cancel ends the conversation with cancellation message', function () {
+test('tapping Cancel ends the conversation with cancellation message and no DB rows are created', function () {
     /** @var TestCase $this */
     MediaTrackingAgent::fake(['Add "The Hobbit" (1937) by J.R.R. Tolkien — Book to your library.']);
     PreTriggeredConfirmation::bind();
@@ -169,6 +165,9 @@ test('tapping Cancel ends the conversation with cancellation message', function 
         ->reply()
         ->assertReplyText('Cancelled. Nothing was changed.', index: 1)
         ->assertNoConversation();
+
+    $this->assertDatabaseCount('media', 0);
+    $this->assertDatabaseCount('media_events', 0);
 });
 
 test('stray text while awaiting confirmation sends a reminder and conversation stays active', function () {
@@ -227,27 +226,6 @@ test('/track persists the conversation to the database', function () {
         'role' => 'assistant',
         'content' => 'Which Dune did you mean?',
     ]);
-});
-
-test('tapping Cancel ends the conversation and no DB rows are created', function () {
-    /** @var TestCase $this */
-    MediaTrackingAgent::fake(['I\'ll add <b>The Hobbit</b> (1937) by J.R.R. Tolkien — Book to your library. Sound good?']);
-    PreTriggeredConfirmation::bind();
-
-    /** @var FakeNutgram $bot */
-    $bot = app(Nutgram::class);
-    $bot->setCommonUser(davidUser());
-    $bot->willStartConversation();
-
-    $bot->hearText('/track Add The Hobbit')->reply();
-
-    $bot->hearCallbackQueryData('cancel')
-        ->reply()
-        ->assertReplyText('Cancelled. Nothing was changed.', index: 1)
-        ->assertNoConversation();
-
-    $this->assertDatabaseCount('media', 0);
-    $this->assertDatabaseCount('media_events', 0);
 });
 
 test('unauthorized user is rejected from /track', function () {

--- a/tests/Feature/Telegram/TrackConversationTest.php
+++ b/tests/Feature/Telegram/TrackConversationTest.php
@@ -145,7 +145,8 @@ test('tapping Confirm calls MediaTrackingAgent with the confirmed plan and sends
 
     $bot->hearCallbackQueryData('confirm')
         ->reply()
-        ->assertReplyText('✓ Added The Hobbit (1937) by J.R.R. Tolkien — Book.', index: 1)
+        ->assertReplyText('On it! I\'ll report back when it\'s done.', index: 2)
+        ->assertReplyText('✓ Added The Hobbit (1937) by J.R.R. Tolkien — Book.', index: 3)
         ->assertNoConversation();
 });
 
@@ -163,7 +164,7 @@ test('tapping Cancel ends the conversation with cancellation message and no DB r
 
     $bot->hearCallbackQueryData('cancel')
         ->reply()
-        ->assertReplyText('Cancelled. Nothing was changed.', index: 1)
+        ->assertReplyText('Cancelled. Nothing was changed.', index: 2)
         ->assertNoConversation();
 
     $this->assertDatabaseCount('media', 0);


### PR DESCRIPTION


- Only inject writing tool after plan is confirmed
- writing tool is itself an agent that takes plans and turns them into database updates (via two tools backed by eloquent queries)


---

Implements actual DB writes when a user taps Confirm in the /track conversation.
Uses MediaTrackingAgent (orchestrator) → MediaWritingAgentTool (worker bridge)
which spins up an anonymous sub-agent with focused write tools.

Changes:
- Migration: drop+recreate media_tracking_summary view to expose creator_id
- SearchMediaQuery: add creator_id to get() columns
- MediaTrackingSummary: add @property docblock for creator_id
- CreateMedia tool: find-or-create Creator + Media, returns created boolean
- CreateMediaEvent tool: insert MediaEvent with absolute ISO 8601 occurred_at
- MediaWritingAgentTool: worker bridge that runs a Sonnet sub-agent with
  SearchMedia + CreateMedia + CreateMediaEvent to execute the confirmed plan
- MediaTrackingAgent: add optional $writingTool constructor param, include in
  tools() when present, append "Executing a Confirmed Plan" instructions section
- TrackConversation: replace placeholder confirm handler with real agent call
  using MediaWritingAgentTool injected into a continued conversation

Tests:
- CreateMediaTest: 8 tests covering creator resolution, firstOrCreate behaviour,
  validation errors, and note storage
- CreateMediaEventTest: 6 tests covering occurred_at precision, comment storage,
  missing media error, and missing MediaEventType surfacing
- MediaTrackingAgentTest: 2 new tests for writingTool injection
- TrackConversationTest: updated Confirm test + new Cancel no-DB-writes test

https://claude.ai/code/session_01KmqyPDnXEWJwSaDNGGLviC