### PR TITLE
Local dev setup with mise and pitchfork

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "20"
+postgres = "17"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 package-lock.json
 composer.lock
+storage/
 
 resources/views/emails
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,8 +2,6 @@
 
 version: "3"
 
-dotenv: [".env.task"]
-
 vars:
   # This is wonky because both Taskfile and docker stats use Go text/template
   # {{`{{`}} is to produce a "{{" literal that will make it to docker stats
@@ -19,9 +17,11 @@ tasks:
   dev:db:start:
     desc: "Start an ephemeral Postgres container with laravel and laravel_test databases"
     cmds:
+      - docker rm -f davidharting-dev-db 2>/dev/null || true
       - docker run -d --name davidharting-dev-db --rm -e POSTGRES_USER=laravel -e POSTGRES_HOST_AUTH_METHOD=trust -e POSTGRES_DB=laravel -p 5432:5432 postgres:17
       - docker exec davidharting-dev-db bash -c 'until pg_isready -U laravel; do sleep 1; done'
       - docker exec davidharting-dev-db createdb -U laravel laravel_test
+      - php artisan migrate:fresh --seed
       - docker attach davidharting-dev-db
 
   dev:db:refresh:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,6 +16,14 @@ tasks:
       - ./vendor/bin/pint
       - npm run format
 
+  dev:db:start:
+    desc: "Start an ephemeral Postgres container with laravel and laravel_test databases"
+    cmds:
+      - docker run -d --name davidharting-dev-db --rm -e POSTGRES_USER=laravel -e POSTGRES_HOST_AUTH_METHOD=trust -e POSTGRES_DB=laravel -p 5432:5432 postgres:17
+      - docker exec davidharting-dev-db bash -c 'until pg_isready -U laravel; do sleep 1; done'
+      - docker exec davidharting-dev-db createdb -U laravel laravel_test
+      - docker attach davidharting-dev-db
+
   dev:db:refresh:
     desc: "Migrate fresh and re-seed"
     cmds:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,7 +23,7 @@
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="database"/>
         <env name="DB_CONNECTION" value="pgsql"/>
-        <env name="DB_DATABASE" value="laravel"/>
+        <env name="DB_DATABASE" value="laravel_test"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="database"/>

--- a/pitchfork.toml
+++ b/pitchfork.toml
@@ -1,0 +1,17 @@
+[daemons.database]
+run = "task dev:db:start"
+ready_cmd = "pg_isready -h 127.0.0.1 -p 5432 -U laravel"
+
+[daemons.php]
+run = "php artisan serve"
+depends = ["database"]
+ready_output = "Development Server started"
+
+[daemons.queue]
+run = "php artisan queue:work"
+depends = ["database"]
+retry = true
+
+[daemons.vite]
+run = "npm run dev"
+ready_output = "ready in"


### PR DESCRIPTION
### What changed

Adds mise for Node/Postgres version management and pitchfork for local dev daemon orchestration, replacing the need to manually start services in separate terminals.

- `.mise.toml`: pins Node 20 and Postgres 17 (PHP managed separately via php.new)
- `pitchfork.toml`: defines `database`, `php`, `queue`, and `vite` daemons with dependency ordering and retry
- `Taskfile.yml`: `dev:db:start` now runs `migrate:fresh --seed` before attaching, cleans up stale containers on re-run

### Why

Running the full local dev stack previously required 4 separate terminals. With pitchfork, `pitchfork start --all` starts everything in the right order — database first, then dependent services — with automatic retry if a service fails on first attempt.

```bash
pitchfork start --all   # start everything
pitchfork tui           # interactive dashboard
pitchfork logs php      # tail a specific service
pitchfork stop --all    # stop everything
```

---

_Generated by [Claude Code](https://docs.anthropic.com/en/docs/claude-code)_