### PR TITLE
Fix tracker agent creating separate comment events instead of embedding comments

### DIFF
--- a/.claude/skills/review-changes/SKILL.md
+++ b/.claude/skills/review-changes/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: review-changes
+description: Post-implementation review. Use after making changes to catch duplication, misplaced additions, and inconsistencies before committing.
+---
+
+# Review Changes
+
+Read the **full content** of every modified file — not just the diff. Then check for:
+
+## What to look for
+
+**Added when should have edited** — Did you append a new section or sentence covering something an existing section already handles? Merge it in instead.
+
+**Duplication** — Same idea, example, or wording appearing more than once. Consolidate to one place.
+
+**Inconsistencies across related files** — When multiple files describe the same concept (e.g. a parameter described in both a schema and an agent prompt), ensure the wording is consistent and neither contradicts the other.
+
+**Incomplete coverage** — A fix applied in one place but not a related place that has the same problem.
+
+## Then fix
+
+Don't just report — fix what you find. Keep fixes minimal: edit existing content rather than adding more.

--- a/.claude/skills/review-changes/SKILL.md
+++ b/.claude/skills/review-changes/SKILL.md
@@ -17,6 +17,8 @@ Read the **full content** of every modified file — not just the diff. Then che
 
 **Incomplete coverage** — A fix applied in one place but not a related place that has the same problem.
 
+**Test placement** — New tests should live inside the existing `describe` block for the method they cover, not appended after it. If a suitable block exists, add to it rather than creating a new one.
+
 ## Then fix
 
 Don't just report — fix what you find. Keep fixes minimal: edit existing content rather than adding more.

--- a/app/Ai/Agents/MediaTrackingAgent.php
+++ b/app/Ai/Agents/MediaTrackingAgent.php
@@ -82,6 +82,8 @@ class MediaTrackingAgent implements Agent, Conversational, HasTools
 
         Supported event types are: started, finished, abandoned, and comment. Comment events do not change the media status — they attach a free-text note to a media item (e.g. a thought, recommendation, or reflection).
 
+        A comment can also be attached directly to a started, finished, or abandoned event — you don't need a separate comment event for that. Use a standalone comment event only when David wants to record a note without logging any status change.
+
         Once you have identified the item and checked the library, confirm back concisely: title, year, primary creator, media type, and current library status.
 
 
@@ -107,6 +109,7 @@ class MediaTrackingAgent implements Agent, Conversational, HasTools
         - "I'll add <b>Ghostwritten</b> (1999) by David Mitchell — Book to your library. Sound good?"
         - "I'll log a <i>finished</i> event for <b>Dune</b> (1965) by Frank Herbert — Book. Sound good?"
         - "I'll add <b>Blood Meridian</b> (1985) by Cormac McCarthy — Book to your library and log a <i>started</i> event. Sound good?"
+        - "I'll log a <i>finished</i> event for <b>Dune</b> (2021) by Denis Villeneuve — Movie, with note: "Stunning visuals". Sound good?"
         - "I'll log a <i>comment</i> on <b>Ace Attorney Investigations: Miles Edgeworth</b>: "I think Katie would like this". Sound good?"
 
         Do not write anything like "Please confirm" or "Use the buttons to confirm". Just state the plan.

--- a/app/Ai/Agents/MediaTrackingAgent.php
+++ b/app/Ai/Agents/MediaTrackingAgent.php
@@ -109,7 +109,7 @@ class MediaTrackingAgent implements Agent, Conversational, HasTools
         - "I'll add <b>Ghostwritten</b> (1999) by David Mitchell — Book to your library. Sound good?"
         - "I'll log a <i>finished</i> event for <b>Dune</b> (1965) by Frank Herbert — Book. Sound good?"
         - "I'll add <b>Blood Meridian</b> (1985) by Cormac McCarthy — Book to your library and log a <i>started</i> event. Sound good?"
-        - "I'll log a <i>finished</i> event for <b>Dune</b> (2021) by Denis Villeneuve — Movie, with note: "Stunning visuals". Sound good?"
+        - "I'll log a <i>finished</i> event for <b>Alien: Romulus</b> (2024) by Fede Álvarez — Movie, with note: "Scary but fun". Sound good?"
         - "I'll log a <i>comment</i> on <b>Ace Attorney Investigations: Miles Edgeworth</b>: "I think Katie would like this". Sound good?"
 
         Do not write anything like "Please confirm" or "Use the buttons to confirm". Just state the plan.

--- a/app/Ai/Tools/CreateMediaEvent.php
+++ b/app/Ai/Tools/CreateMediaEvent.php
@@ -79,7 +79,7 @@ class CreateMediaEvent implements Tool
             'occurred_at' => $schema->string()->required()
                 ->description('When the event occurred. Accepts ISO 8601, plain dates, or natural language Carbon can parse. If no time was mentioned, use noon (12:00:00) of the relevant day, e.g. "2026-03-15T12:00:00".'),
             'comment' => $schema->string()
-                ->description('An optional comment for comment-type events or annotations.'),
+                ->description('An optional free-text note to attach to this event. Can be used with any event type (started, finished, abandoned, or comment). When logging a started or finished event with a remark, pass the remark here — do NOT create a separate comment event.'),
         ];
     }
 }

--- a/app/Ai/Tools/CreateMediaEvent.php
+++ b/app/Ai/Tools/CreateMediaEvent.php
@@ -79,7 +79,7 @@ class CreateMediaEvent implements Tool
             'occurred_at' => $schema->string()->required()
                 ->description('When the event occurred. Accepts ISO 8601, plain dates, or natural language Carbon can parse. If no time was mentioned, use noon (12:00:00) of the relevant day, e.g. "2026-03-15T12:00:00".'),
             'comment' => $schema->string()
-                ->description('An optional free-text note to attach to this event. Can be used with any event type (started, finished, abandoned, or comment). When logging a started or finished event with a remark, pass the remark here — do NOT create a separate comment event.'),
+                ->description('An optional free-text note to attach to this event. Can be used with any event type (started, finished, abandoned, or comment). When logging a started, finished, or abandoned event with a remark, pass the remark here — do NOT create a separate comment event.'),
         ];
     }
 }

--- a/app/Ai/Tools/MediaWritingAgentTool.php
+++ b/app/Ai/Tools/MediaWritingAgentTool.php
@@ -64,6 +64,9 @@ class MediaWritingAgentTool implements Tool
         **Backlog only**
         If the plan is to add to the library with no event, call CreateMedia only.
 
+        **Comments on events**
+        If the plan includes a remark, note, or comment alongside a started, finished, or abandoned event, pass it as the `comment` parameter to CreateMediaEvent — do NOT create a separate comment event. Only create a standalone comment event when the plan explicitly calls for logging a comment with no other event.
+
         **Return value**
         Return a concise plain-text summary of exactly what was written.
         Example: "Added The Hobbit (1937) by J.R.R. Tolkien — Book. Logged a started event on March 27, 2026."

--- a/tests/Feature/Ai/Tools/CreateMediaEventTest.php
+++ b/tests/Feature/Ai/Tools/CreateMediaEventTest.php
@@ -54,7 +54,7 @@ describe('handle()', function () {
         ]);
     });
 
-    test('attaches comment to a started event', function () {
+    test('attaches comment to a non-comment event without creating a separate event', function () {
         /** @var TestCase $this */
         $media = Media::factory()->book()->create();
 
@@ -74,31 +74,6 @@ describe('handle()', function () {
             'media_id' => $media->id,
             'comment' => 'Really excited for this one.',
         ]);
-        // Only one event should exist — not a separate comment event
-        $this->assertSame(1, MediaEvent::where('media_id', $media->id)->count());
-    });
-
-    test('attaches comment to a finished event', function () {
-        /** @var TestCase $this */
-        $media = Media::factory()->book()->create();
-
-        $result = json_decode(
-            (new CreateMediaEvent)->handle(new Request([
-                'media_id' => $media->id,
-                'event_type' => 'finished',
-                'occurred_at' => '2026-03-15T12:00:00Z',
-                'comment' => 'Stunning visuals.',
-            ])),
-            true,
-        );
-
-        $this->assertArrayHasKey('event_id', $result);
-        $this->assertSame('finished', $result['event_type']);
-        $this->assertDatabaseHas('media_events', [
-            'media_id' => $media->id,
-            'comment' => 'Stunning visuals.',
-        ]);
-        // Only one event should exist — not a separate comment event
         $this->assertSame(1, MediaEvent::where('media_id', $media->id)->count());
     });
 

--- a/tests/Feature/Ai/Tools/CreateMediaEventTest.php
+++ b/tests/Feature/Ai/Tools/CreateMediaEventTest.php
@@ -54,6 +54,54 @@ describe('handle()', function () {
         ]);
     });
 
+    test('attaches comment to a started event', function () {
+        /** @var TestCase $this */
+        $media = Media::factory()->book()->create();
+
+        $result = json_decode(
+            (new CreateMediaEvent)->handle(new Request([
+                'media_id' => $media->id,
+                'event_type' => 'started',
+                'occurred_at' => '2026-03-15T12:00:00Z',
+                'comment' => 'Really excited for this one.',
+            ])),
+            true,
+        );
+
+        $this->assertArrayHasKey('event_id', $result);
+        $this->assertSame('started', $result['event_type']);
+        $this->assertDatabaseHas('media_events', [
+            'media_id' => $media->id,
+            'comment' => 'Really excited for this one.',
+        ]);
+        // Only one event should exist — not a separate comment event
+        $this->assertSame(1, MediaEvent::where('media_id', $media->id)->count());
+    });
+
+    test('attaches comment to a finished event', function () {
+        /** @var TestCase $this */
+        $media = Media::factory()->book()->create();
+
+        $result = json_decode(
+            (new CreateMediaEvent)->handle(new Request([
+                'media_id' => $media->id,
+                'event_type' => 'finished',
+                'occurred_at' => '2026-03-15T12:00:00Z',
+                'comment' => 'Stunning visuals.',
+            ])),
+            true,
+        );
+
+        $this->assertArrayHasKey('event_id', $result);
+        $this->assertSame('finished', $result['event_type']);
+        $this->assertDatabaseHas('media_events', [
+            'media_id' => $media->id,
+            'comment' => 'Stunning visuals.',
+        ]);
+        // Only one event should exist — not a separate comment event
+        $this->assertSame(1, MediaEvent::where('media_id', $media->id)->count());
+    });
+
     test('returns error when media_id not found', function () {
         /** @var TestCase $this */
         $result = json_decode(


### PR DESCRIPTION
Three prompt/schema issues caused the agent to create a standalone comment
event rather than attaching the comment to a started/finished/abandoned event:

1. CreateMediaEvent schema described `comment` as "for comment-type events",
   biasing the writing agent to use event_type=comment. Updated to explicitly
   say the field works on any event type and to NOT create a separate event.

2. MediaWritingAgentTool instructions had no guidance on comments. Added a
   section telling the agent to pass `comment` to CreateMediaEvent rather than
   creating a standalone comment event when a remark accompanies a status event.

3. MediaTrackingAgent instructions described event types but gave no example of
   a confirmation with an embedded comment on a started/finished event. Added an
   example and a clarifying sentence about when to use standalone comment events.

Tests: added two new cases for comment attached to started and finished events.

https://claude.ai/code/session_01Fkffwdf6pGKTV7XxfARg7h