### PR TITLE
Add agent evals directory and happy-path eval for MediaTrackingAgent

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches:
       - main
@@ -58,6 +59,50 @@ jobs:
           DB_USERNAME: root
           DB_PASSWORD: password
         run: php artisan test --compact --do-not-cache-result
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: root
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: laravel_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+  evals:
+    name: "Agent Evals"
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'ci:eval')
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Copy .env
+        run: cp .env.example .env
+
+      - name: Install composer dependencies
+        run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
+
+      - name: Generate key
+        run: php artisan key:generate
+
+      - name: Run evals
+        env:
+          DB_USERNAME: root
+          DB_PASSWORD: password
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: php artisan test tests/Evals/ --compact
 
     services:
       postgres:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,44 +60,8 @@ jobs:
           DB_PASSWORD: password
         run: php artisan test --compact --do-not-cache-result
 
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: root
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: laravel_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-  evals:
-    name: "Agent Evals"
-    runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'ci:eval')
-    steps:
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "8.4"
-
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Copy .env
-        run: cp .env.example .env
-
-      - name: Install composer dependencies
-        run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
-
-      - name: Generate key
-        run: php artisan key:generate
-
       - name: Run evals
+        if: contains(github.event.pull_request.labels.*.name, 'ci:eval')
         env:
           DB_USERNAME: root
           DB_PASSWORD: password

--- a/tests/Evals/MediaTrackingAgentEvalTest.php
+++ b/tests/Evals/MediaTrackingAgentEvalTest.php
@@ -7,6 +7,17 @@ use App\Models\Media;
 use App\Models\MediaEventType;
 use Illuminate\Foundation\Testing\TestCase;
 use Laravel\Ai\Contracts\ConversationStore;
+use Laravel\Ai\Responses\AgentResponse;
+
+function evalMetrics(string $label, float $startedAt, AgentResponse $response): void
+{
+    $elapsed = round((microtime(true) - $startedAt) * 1000);
+    $tools = collect($response->toolCalls)->pluck('name')->join(', ') ?: '(none)';
+    $steps = count($response->steps);
+    $usage = $response->usage;
+
+    dump("[{$label}] {$elapsed}ms | {$steps} steps | tools: {$tools} | tokens in={$usage->promptTokens} out={$usage->completionTokens} cache_read={$usage->cacheReadInputTokens} cache_write={$usage->cacheWriteInputTokens}");
+}
 
 test('happy path: user logs a finished book', function () {
     /** @var TestCase $this */
@@ -25,7 +36,9 @@ test('happy path: user logs a finished book', function () {
     $confirmationTool = new RequestConfirmation;
     $agent = (new MediaTrackingAgent(confirmationTool: $confirmationTool))
         ->continue($conversationId, $user);
-    $agent->prompt('I just finished reading Dune by Frank Herbert');
+    $t1 = microtime(true);
+    $response1 = $agent->prompt('I just finished reading Dune by Frank Herbert');
+    evalMetrics('turn 1', $t1, $response1);
 
     expect($confirmationTool->wasRequested())->toBeTrue('Agent should have called RequestConfirmation');
 
@@ -33,7 +46,9 @@ test('happy path: user logs a finished book', function () {
     $writingTool = new MediaWritingAgentTool;
     $agent = (new MediaTrackingAgent(writingTool: $writingTool))
         ->continue($conversationId, $user);
-    $agent->prompt('The user confirmed. Execute the plan.');
+    $t2 = microtime(true);
+    $response2 = $agent->prompt('The user confirmed. Execute the plan.');
+    evalMetrics('turn 2', $t2, $response2);
 
     // Assert the media record was created
     $media = Media::where('title', 'like', '%Dune%')->first();

--- a/tests/Evals/MediaTrackingAgentEvalTest.php
+++ b/tests/Evals/MediaTrackingAgentEvalTest.php
@@ -6,17 +6,26 @@ use App\Ai\Tools\RequestConfirmation;
 use App\Models\Media;
 use App\Models\MediaEventType;
 use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\Support\Facades\Log;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Responses\AgentResponse;
 
 function evalMetrics(string $label, float $startedAt, AgentResponse $response): void
 {
-    $elapsed = round((microtime(true) - $startedAt) * 1000);
-    $tools = collect($response->toolCalls)->pluck('name')->join(', ') ?: '(none)';
-    $steps = count($response->steps);
     $usage = $response->usage;
 
-    dump("[{$label}] {$elapsed}ms | {$steps} steps | tools: {$tools} | tokens in={$usage->promptTokens} out={$usage->completionTokens} cache_read={$usage->cacheReadInputTokens} cache_write={$usage->cacheWriteInputTokens}");
+    Log::info('eval.turn', [
+        'turn' => $label,
+        'elapsed_ms' => (int) round((microtime(true) - $startedAt) * 1000),
+        'steps' => count($response->steps),
+        'tools' => collect($response->toolCalls)->pluck('name')->all(),
+        'tokens' => [
+            'input' => $usage->promptTokens,
+            'output' => $usage->completionTokens,
+            'cache_read' => $usage->cacheReadInputTokens,
+            'cache_write' => $usage->cacheWriteInputTokens,
+        ],
+    ]);
 }
 
 test('happy path: user logs a finished book', function () {

--- a/tests/Evals/MediaTrackingAgentEvalTest.php
+++ b/tests/Evals/MediaTrackingAgentEvalTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Ai\Agents\MediaTrackingAgent;
+use App\Ai\Tools\MediaWritingAgentTool;
+use App\Ai\Tools\RequestConfirmation;
+use App\Models\Media;
+use App\Models\MediaEventType;
+use Illuminate\Foundation\Testing\TestCase;
+use Laravel\Ai\Contracts\ConversationStore;
+
+test('happy path: user logs a finished book', function () {
+    /** @var TestCase $this */
+    expect(config('ai.providers.anthropic.api_key'))
+        ->not->toBeEmpty('Set ANTHROPIC_API_KEY to run evals');
+
+    $conversationId = app(ConversationStore::class)
+        ->storeConversation(null, 'I finished reading Dune');
+
+    $user = new class
+    {
+        public ?int $id = null;
+    };
+
+    // Turn 1: agent identifies the book, checks library, requests confirmation
+    $confirmationTool = new RequestConfirmation;
+    $agent = (new MediaTrackingAgent(confirmationTool: $confirmationTool))
+        ->continue($conversationId, $user);
+    $agent->prompt('I just finished reading Dune by Frank Herbert');
+
+    expect($confirmationTool->wasRequested())->toBeTrue('Agent should have called RequestConfirmation');
+
+    // Turn 2: user confirms — agent executes the plan
+    $writingTool = new MediaWritingAgentTool;
+    $agent = (new MediaTrackingAgent(writingTool: $writingTool))
+        ->continue($conversationId, $user);
+    $agent->prompt('The user confirmed. Execute the plan.');
+
+    // Assert the media record was created
+    $media = Media::where('title', 'like', '%Dune%')->first();
+    expect($media)->not->toBeNull('A Dune media record should exist in the database');
+
+    // Assert a finished event was created
+    $this->assertDatabaseHas('media_events', [
+        'media_id' => $media->id,
+        'media_event_type_id' => MediaEventType::where('name', 'finished')->value('id'),
+    ]);
+});

--- a/tests/Evals/MediaTrackingAgentEvalTest.php
+++ b/tests/Evals/MediaTrackingAgentEvalTest.php
@@ -8,25 +8,6 @@ use App\Models\MediaEventType;
 use Illuminate\Foundation\Testing\TestCase;
 use Illuminate\Support\Facades\Log;
 use Laravel\Ai\Contracts\ConversationStore;
-use Laravel\Ai\Responses\AgentResponse;
-
-function evalMetrics(string $label, float $startedAt, AgentResponse $response): void
-{
-    $usage = $response->usage;
-
-    Log::info('eval.turn', [
-        'turn' => $label,
-        'elapsed_ms' => (int) round((microtime(true) - $startedAt) * 1000),
-        'steps' => count($response->steps),
-        'tools' => collect($response->toolCalls)->pluck('name')->all(),
-        'tokens' => [
-            'input' => $usage->promptTokens,
-            'output' => $usage->completionTokens,
-            'cache_read' => $usage->cacheReadInputTokens,
-            'cache_write' => $usage->cacheWriteInputTokens,
-        ],
-    ]);
-}
 
 test('happy path: user logs a finished book', function () {
     /** @var TestCase $this */
@@ -41,13 +22,13 @@ test('happy path: user logs a finished book', function () {
         public ?int $id = null;
     };
 
+    $startedAt = microtime(true);
+
     // Turn 1: agent identifies the book, checks library, requests confirmation
     $confirmationTool = new RequestConfirmation;
     $agent = (new MediaTrackingAgent(confirmationTool: $confirmationTool))
         ->continue($conversationId, $user);
-    $t1 = microtime(true);
     $response1 = $agent->prompt('I just finished reading Dune by Frank Herbert');
-    evalMetrics('turn 1', $t1, $response1);
 
     expect($confirmationTool->wasRequested())->toBeTrue('Agent should have called RequestConfirmation');
 
@@ -55,9 +36,7 @@ test('happy path: user logs a finished book', function () {
     $writingTool = new MediaWritingAgentTool;
     $agent = (new MediaTrackingAgent(writingTool: $writingTool))
         ->continue($conversationId, $user);
-    $t2 = microtime(true);
     $response2 = $agent->prompt('The user confirmed. Execute the plan.');
-    evalMetrics('turn 2', $t2, $response2);
 
     // Assert the media record was created
     $media = Media::where('title', 'like', '%Dune%')->first();
@@ -67,5 +46,18 @@ test('happy path: user logs a finished book', function () {
     $this->assertDatabaseHas('media_events', [
         'media_id' => $media->id,
         'media_event_type_id' => MediaEventType::where('name', 'finished')->value('id'),
+    ]);
+
+    $u1 = $response1->usage;
+    $u2 = $response2->usage;
+    Log::info('eval', [
+        'eval' => 'happy path: user logs a finished book',
+        'elapsed_ms' => (int) round((microtime(true) - $startedAt) * 1000),
+        'tokens' => [
+            'input' => $u1->promptTokens + $u2->promptTokens,
+            'output' => $u1->completionTokens + $u2->completionTokens,
+            'cache_read' => $u1->cacheReadInputTokens + $u2->cacheReadInputTokens,
+            'cache_write' => $u1->cacheWriteInputTokens + $u2->cacheWriteInputTokens,
+        ],
     ]);
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -19,6 +19,11 @@ uses(
     RefreshDatabase::class,
 )->in('Feature');
 
+uses(
+    TestCase::class,
+    RefreshDatabase::class,
+)->in('Evals');
+
 /*
 |--------------------------------------------------------------------------
 | Expectations


### PR DESCRIPTION
Creates tests/Evals/ as a top-level directory outside the Unit and Feature
test suites in phpunit.xml, so evals never run with `php artisan test` by
default. Run them explicitly with `php artisan test tests/Evals/`.

The first eval covers the happy path: the agent receives "I just finished
reading Dune by Frank Herbert", requests confirmation after identifying the
book and checking the library, then executes the write on the second turn.
Asserts both the media record and finished event are created in the database.

Evals use the real Anthropic API (ANTHROPIC_API_KEY must be set) and a real
database via RefreshDatabase.

https://claude.ai/code/session_0159hH1QFFypf4oHkWkgFKDJ