### PR TITLE
Apply JSON format to Caddy's global system log

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,10 @@
 {
 	admin off
 
+	log {
+		format {$CADDY_SERVER_LOGGER}
+	}
+
 	frankenphp {
 		worker "{$APP_PUBLIC_PATH}/frankenphp-worker.php" {$CADDY_SERVER_WORKER_COUNT}
 	}
@@ -39,4 +43,3 @@
 		}
 	}
 }
-


### PR DESCRIPTION
## Summary

- The previous PR fixed Laravel app logs and Caddy access logs (HTTP requests), but Caddy's own system log — startup messages, errors, warnings — was a separate channel defaulting to console format. That's why you were still seeing `   ERROR  unknown error.  ` in plain text after deploy.
- Adding a `log { format {$CADDY_SERVER_LOGGER} }` block in the global Caddyfile options applies the same `json`/`console` toggle to system logs. In production this means all Caddy output is now structured JSON.
- Also ran `caddy fmt --overwrite` to silence the Caddyfile formatting warning that appeared in the deploy logs.

## Test plan

- [ ] Deploy and confirm system log lines (`ERROR`, `INFO`, `WARN`) appear as JSON objects in Render logs
- [ ] Confirm the `Caddyfile input is not formatted` warning is gone from deploy output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NME7vFQ4dRMNcYXTjudYXP

---
_Generated by [Claude Code](https://claude.ai/code/session_01NME7vFQ4dRMNcYXTjudYXP)_