### PR TITLE
Make the Telegram bot recover from errors and curb the retry storm

### DIFF
--- a/app/Telegram/Conversations/TrackConversation.php
+++ b/app/Telegram/Conversations/TrackConversation.php
@@ -6,14 +6,18 @@ use App\Ai\Agents\MediaTrackingAgent;
 use App\Ai\Tools\MediaWritingAgentTool;
 use App\Ai\Tools\RequestConfirmation;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use SergiX44\Nutgram\Conversations\Conversation;
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Telegram\Properties\ParseMode;
 use SergiX44\Nutgram\Telegram\Types\Keyboard\InlineKeyboardButton;
 use SergiX44\Nutgram\Telegram\Types\Keyboard\InlineKeyboardMarkup;
+use Throwable;
 
 class TrackConversation extends Conversation
 {
@@ -69,11 +73,23 @@ class TrackConversation extends Conversation
 
         if ($bot->callbackQuery()?->data === 'confirm') {
             $bot->sendMessage('On it! I\'ll report back when it\'s done.');
-            $writingTool = new MediaWritingAgentTool;
-            $agent = (new MediaTrackingAgent(writingTool: $writingTool))
-                ->continue($this->aiConversationId, $this->conversationUser());
-            $response = $agent->prompt('The user confirmed. Execute the plan.');
-            $bot->sendMessage($response->text, parse_mode: ParseMode::HTML);
+
+            try {
+                $writingTool = new MediaWritingAgentTool;
+                $agent = (new MediaTrackingAgent(writingTool: $writingTool))
+                    ->continue($this->aiConversationId, $this->conversationUser());
+                $response = $this->promptWithRetry($agent, 'The user confirmed. Execute the plan.');
+                $bot->sendMessage(
+                    $this->textOr($response->text, '✓ Done.'),
+                    parse_mode: ParseMode::HTML,
+                );
+            } catch (AiException $e) {
+                Log::error('MediaTrackingAgent execution failed', ['exception' => $e]);
+                $bot->sendMessage("Error: {$e->getMessage()}");
+            } catch (Throwable $e) {
+                Log::error('TrackConversation execution failed unexpectedly', ['exception' => $e]);
+                $bot->sendMessage('Sorry, something went wrong while saving that. Please try again.');
+            }
         } else {
             $bot->sendMessage('Conversation ended.');
         }
@@ -95,11 +111,16 @@ class TrackConversation extends Conversation
             $agent = (new MediaTrackingAgent($confirmationTool))
                 ->continue($this->aiConversationId, $this->conversationUser());
 
-            $response = $agent->prompt($userText);
+            $response = $this->promptWithRetry($agent, $userText);
 
             if ($confirmationTool->wasRequested()) {
+                // The agent is instructed to write the confirmation summary as its
+                // response text when it calls RequestConfirmation, but it sometimes
+                // emits only the tool call with no text. Fall back so we never send
+                // Telegram an empty message (which fails with "message text is empty"
+                // and 500s the webhook, triggering a retry storm).
                 $bot->sendMessage(
-                    $response->text,
+                    $this->textOr($response->text, 'Ready to log this. Confirm?'),
                     reply_markup: InlineKeyboardMarkup::make()->addRow(
                         InlineKeyboardButton::make('✓ Confirm', callback_data: 'confirm'),
                         InlineKeyboardButton::make('End', callback_data: 'end'),
@@ -109,7 +130,7 @@ class TrackConversation extends Conversation
                 $this->next('awaitConfirmation');
             } else {
                 $bot->sendMessage(
-                    $response->text,
+                    $this->textOr($response->text, "Sorry, I didn't catch that. Could you say it another way?"),
                     reply_markup: InlineKeyboardMarkup::make()->addRow(
                         InlineKeyboardButton::make('End', callback_data: 'end'),
                     ),
@@ -118,10 +139,61 @@ class TrackConversation extends Conversation
                 $this->next('converse');
             }
         } catch (AiException $e) {
-            // TODO: Retry with exponential backoff before giving up (consider adding to the agent itself).
+            // Provider failures that survived promptWithRetry (e.g. insufficient
+            // credits, or exhausted transient retries). Surface the reason so David
+            // knows what happened, and end the turn with a 200 so Telegram does not
+            // retry the whole expensive agent run.
             Log::error('MediaTrackingAgent failed', ['exception' => $e]);
             $bot->sendMessage("Error: {$e->getMessage()}");
             $this->end();
+        } catch (Throwable $e) {
+            // Any other unexpected failure (a bug, a Telegram API rejection, etc.).
+            // Reply so David isn't left hanging and return normally (200) to stop
+            // Telegram from retrying. Genuine infrastructure failures happen outside
+            // this handler and still 500, so Telegram can redeliver those.
+            Log::error('TrackConversation turn failed unexpectedly', ['exception' => $e]);
+            $bot->sendMessage('Sorry, something went wrong on my end. Please try again.');
+            $this->end();
         }
+    }
+
+    /**
+     * Run an agent prompt, retrying transient provider failures (overloaded or
+     * rate limited) a few times with exponential backoff before giving up.
+     * Deterministic failures (e.g. insufficient credits) are not retried.
+     */
+    private function promptWithRetry(MediaTrackingAgent $agent, string $prompt, int $maxAttempts = 3): mixed
+    {
+        $attempt = 1;
+
+        while (true) {
+            try {
+                return $agent->prompt($prompt);
+            } catch (ProviderOverloadedException|RateLimitedException $e) {
+                if ($attempt >= $maxAttempts) {
+                    throw $e;
+                }
+
+                Log::warning('MediaTrackingAgent transient failure; retrying', [
+                    'attempt' => $attempt,
+                    'exception' => $e->getMessage(),
+                ]);
+
+                // Backoff of 1s then 2s, kept short so the synchronous webhook stays
+                // well within Telegram's timeout on top of the agent's own latency.
+                Sleep::for(2 ** ($attempt - 1))->seconds();
+
+                $attempt++;
+            }
+        }
+    }
+
+    /**
+     * Return the given text, or a fallback when it is empty, so we never hand
+     * Telegram a blank message (which it rejects with "message text is empty").
+     */
+    private function textOr(?string $text, string $fallback): string
+    {
+        return filled($text) ? $text : $fallback;
     }
 }

--- a/tests/Feature/Telegram/TrackConversationTest.php
+++ b/tests/Feature/Telegram/TrackConversationTest.php
@@ -3,7 +3,9 @@
 use App\Ai\Agents\MediaTrackingAgent;
 use App\Ai\Tools\RequestConfirmation;
 use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\Support\Sleep;
 use Laravel\Ai\Exceptions\InsufficientCreditsException;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Tools\Request;
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Telegram\Types\User\User;
@@ -234,6 +236,116 @@ test('/track persists the conversation to the database', function () {
         'role' => 'assistant',
         'content' => 'Which Dune did you mean?',
     ]);
+});
+
+test('/track falls back to a default confirmation message when agent text is empty', function () {
+    /** @var TestCase $this */
+    // The agent called RequestConfirmation but emitted no response text. We must
+    // not send Telegram an empty message (it rejects it with a 400).
+    MediaTrackingAgent::fake(['']);
+    PreTriggeredConfirmation::bind();
+
+    /** @var FakeNutgram $bot */
+    $bot = app(Nutgram::class);
+    $bot->setCommonUser(davidUser());
+    $bot->willStartConversation();
+
+    $bot->hearText('/track Add The Hobbit')
+        ->reply()
+        ->assertReplyText('Ready to log this. Confirm?')
+        ->assertReplyMessage([
+            'reply_markup' => [
+                'inline_keyboard' => [[
+                    ['text' => '✓ Confirm', 'callback_data' => 'confirm'],
+                    ['text' => 'End', 'callback_data' => 'end'],
+                ]],
+            ],
+        ])
+        ->assertActiveConversation();
+});
+
+test('/track falls back to a default plain message when agent text is empty', function () {
+    /** @var TestCase $this */
+    MediaTrackingAgent::fake(['']);
+
+    /** @var FakeNutgram $bot */
+    $bot = app(Nutgram::class);
+    $bot->setCommonUser(davidUser());
+    $bot->willStartConversation();
+
+    $bot->hearText('/track mark dune as finished')
+        ->reply()
+        ->assertReplyText("Sorry, I didn't catch that. Could you say it another way?")
+        ->assertActiveConversation();
+});
+
+test('/track recovers from an unexpected error and replies instead of throwing', function () {
+    /** @var TestCase $this */
+    // A non-AiException (e.g. a bug or a Telegram API rejection) must not bubble
+    // up and 500 the webhook — that is what causes Telegram's retry storm.
+    MediaTrackingAgent::fake(fn () => throw new RuntimeException('boom'));
+
+    /** @var FakeNutgram $bot */
+    $bot = app(Nutgram::class);
+    $bot->setCommonUser(davidUser());
+    $bot->willStartConversation();
+
+    $bot->hearText('/track Add The Hobbit')
+        ->reply()
+        ->assertReplyText('Sorry, something went wrong on my end. Please try again.')
+        ->assertNoConversation();
+});
+
+test('/track retries a transient provider failure and then succeeds', function () {
+    /** @var TestCase $this */
+    Sleep::fake();
+
+    $calls = 0;
+    MediaTrackingAgent::fake(function () use (&$calls) {
+        $calls++;
+
+        if ($calls === 1) {
+            throw new ProviderOverloadedException('overloaded');
+        }
+
+        return 'Which Dune did you mean?';
+    });
+
+    /** @var FakeNutgram $bot */
+    $bot = app(Nutgram::class);
+    $bot->setCommonUser(davidUser());
+    $bot->willStartConversation();
+
+    $bot->hearText('/track mark dune as finished')
+        ->reply()
+        ->assertReplyText('Which Dune did you mean?')
+        ->assertActiveConversation();
+
+    expect($calls)->toBe(2);
+});
+
+test('/track gives up after exhausting transient retries and reports the error', function () {
+    /** @var TestCase $this */
+    Sleep::fake();
+
+    $calls = 0;
+    MediaTrackingAgent::fake(function () use (&$calls) {
+        $calls++;
+        throw new ProviderOverloadedException('overloaded');
+    });
+
+    /** @var FakeNutgram $bot */
+    $bot = app(Nutgram::class);
+    $bot->setCommonUser(davidUser());
+    $bot->willStartConversation();
+
+    $bot->hearText('/track mark dune as finished')
+        ->reply()
+        ->assertReplyText('Error: overloaded')
+        ->assertNoConversation();
+
+    // Three attempts total: the initial try plus two retries.
+    expect($calls)->toBe(3);
 });
 
 test('unauthorized user is rejected from /track', function () {


### PR DESCRIPTION
The /track conversation could fail in ways that 500'd the webhook, which
made Telegram retry the same update and re-run the whole expensive agent
turn (web search + multiple LLM calls), burning tokens and leaving David
with no reply.

Two concrete failure modes were observed in production:

  - When the agent calls RequestConfirmation it is supposed to also emit the
    confirmation summary as its response text, but it sometimes emits only
    the tool call. We then sent an empty message, which Telegram rejects with
    "Bad Request: message text is empty" (400).
  - That TelegramException was not an AiException, so runAgentTurn's catch
    didn't handle it; it bubbled up and the webhook returned 500.

Changes:

  - Guard every outgoing message with a non-empty fallback (textOr) so we
    never hand Telegram a blank message.
  - Broaden error handling: keep the AiException branch (surfaces the provider
    reason to David) and add a Throwable branch for anything unexpected. Both
    reply to David and return normally (200) so Telegram does not retry.
    Genuine infrastructure failures still occur outside this handler and 500,
    so Telegram can still redeliver those — we curb the storm without losing
    all retries.
  - Add promptWithRetry: retry only transient provider failures
    (ProviderOverloadedException, RateLimitedException) up to 3 attempts with
    1s/2s backoff via Illuminate\Support\Sleep, then give up. Deterministic
    failures (e.g. insufficient credits) are not retried. This replaces the
    old "TODO: retry with backoff" note.
  - Apply the same recovery + retry + empty-text fallback to the confirmed-plan
    execution path in awaitConfirmation.

Tests cover empty-text fallbacks (confirmation and plain), unexpected-error
recovery, transient retry-then-success, and retry exhaustion. Sleep::fake()
keeps the retry tests instant.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R3Ec3YrVZBaUm3vAN6BzQW