### PR TITLE
Set up Render preview environments for pull requests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -25,7 +25,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        if (! App::environment('local')) {
+        if (! App::environment('local') && ! env('DB_SEED')) {
             throw new Exception('This seeder can only be run in the local environment');
         }
         User::factory()->create([

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -26,7 +26,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         if (! App::environment('local') && ! env('RUN_DEV_SEEDER')) {
-            throw new Exception('This seeder can only be run in the local environment');
+            throw new Exception('This seeder can only be run in the local environment or with RUN_DEV_SEEDER=true');
         }
         User::factory()->create([
             'name' => 'Adam Min',

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -25,7 +25,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        if (! App::environment('local') && ! env('DB_SEED')) {
+        if (! App::environment('local') && ! env('RUN_DEV_SEEDER')) {
             throw new Exception('This seeder can only be run in the local environment');
         }
         User::factory()->create([

--- a/render.yaml
+++ b/render.yaml
@@ -81,7 +81,7 @@ projects:
               # R2 credentials/buckets and Telegram bot token).
               - key: RENDER_SECRETS_ENV_FILE
                 value: /etc/secrets/secrets.env
-                previewValue: /etc/secrets/staging.env
+                previewValue: /etc/secrets/staging.secrets.env
 
         services:
           - name: davidhartingdotcom-web

--- a/render.yaml
+++ b/render.yaml
@@ -92,6 +92,7 @@ projects:
             plan: starter
             previews:
               plan: starter
+            initialDeployHook: bash /app/scripts/render-with-secrets.sh bash /app/scripts/seed.sh
             region: ohio
             dockerfilePath: ./Dockerfile
             autoDeployTrigger: checksPass

--- a/render.yaml
+++ b/render.yaml
@@ -82,7 +82,7 @@ projects:
               - key: RENDER_SECRETS_ENV_FILE
                 value: /etc/secrets/secrets.env
                 previewValue: /etc/secrets/staging.secrets.env
-              - key: DB_SEED
+              - key: RUN_DEV_SEEDER
                 value: "false"
                 previewValue: "true"
 

--- a/render.yaml
+++ b/render.yaml
@@ -58,10 +58,10 @@ projects:
                 value: r2-public
               - key: R2_PUBLIC_BUCKET
                 value: davidhartingdotcom-public
-                previewValue: FIXME-preview-r2-public-bucket
+                previewValue: staging-davidhartingdotcom-public
               - key: R2_PUBLIC_URL
                 value: https://cdn.davidharting.com
-                previewValue: FIXME-preview-r2-public-url
+                previewValue: https://staging.cdn.davidharting.com
 
               - key: MAIL_MAILER
                 value: mailersend
@@ -75,8 +75,13 @@ projects:
               - key: OCTANE_HTTPS
                 value: "false"
 
-              # Secrets are mounted as /etc/secrets/secrets.env and linked to
-              # /app/.env by scripts/render-with-secrets.sh at runtime.
+              # Secrets are mounted as secret files and linked to /app/.env by
+              # scripts/render-with-secrets.sh at runtime. Production loads
+              # secrets.env; preview environments load staging.env (different
+              # R2 credentials/buckets and Telegram bot token).
+              - key: RENDER_SECRETS_ENV_FILE
+                value: /etc/secrets/secrets.env
+                previewValue: /etc/secrets/staging.env
 
         services:
           - name: davidhartingdotcom-web

--- a/render.yaml
+++ b/render.yaml
@@ -2,6 +2,13 @@ previews:
   generation: automatic
   expireAfterDays: 2
 
+# Workspace-level group (outside the project) so its secret file
+# (staging.secrets.env) is available to ephemeral preview services,
+# which are not part of the prod environment.
+envVarGroups:
+  - name: davidhartingdotcom-preview-env-secrets
+    envVars: []
+
 projects:
   - name: davidhartingdotcom
     environments:
@@ -130,6 +137,7 @@ projects:
             preDeployCommand: bash /app/scripts/render-with-secrets.sh bash /app/scripts/predeploy.sh
             envVars:
               - fromGroup: davidhartingdotcom-shared
+              - fromGroup: davidhartingdotcom-preview-env-secrets
               - key: DATABASE_URL
                 fromDatabase:
                   name: davidhartingdotcom-db
@@ -150,6 +158,7 @@ projects:
             dockerCommand: bash /app/scripts/render-with-secrets.sh php artisan queue:work -v --tries=3 --backoff=30
             envVars:
               - fromGroup: davidhartingdotcom-shared
+              - fromGroup: davidhartingdotcom-preview-env-secrets
               - key: DATABASE_URL
                 fromDatabase:
                   name: davidhartingdotcom-db
@@ -169,6 +178,7 @@ projects:
             dockerCommand: bash /app/scripts/render-with-secrets.sh php artisan backup:run --only-db
             envVars:
               - fromGroup: davidhartingdotcom-shared
+              - fromGroup: davidhartingdotcom-preview-env-secrets
               - key: DATABASE_URL
                 fromDatabase:
                   name: davidhartingdotcom-db
@@ -188,6 +198,7 @@ projects:
             dockerCommand: bash /app/scripts/render-with-secrets.sh php artisan backup:clean
             envVars:
               - fromGroup: davidhartingdotcom-shared
+              - fromGroup: davidhartingdotcom-preview-env-secrets
               - key: DATABASE_URL
                 fromDatabase:
                   name: davidhartingdotcom-db

--- a/render.yaml
+++ b/render.yaml
@@ -1,3 +1,7 @@
+previews:
+  generation: automatic
+  expireAfterDays: 2
+
 projects:
   - name: davidhartingdotcom
     environments:
@@ -7,6 +11,7 @@ projects:
             databaseName: laravel
             user: laravel
             plan: basic-256mb
+            previewPlan: basic-256mb
             postgresMajorVersion: "17"
             region: ohio
             diskSizeGB: 1
@@ -53,8 +58,10 @@ projects:
                 value: r2-public
               - key: R2_PUBLIC_BUCKET
                 value: davidhartingdotcom-public
+                previewValue: FIXME-preview-r2-public-bucket
               - key: R2_PUBLIC_URL
                 value: https://cdn.davidharting.com
+                previewValue: FIXME-preview-r2-public-url
 
               - key: MAIL_MAILER
                 value: mailersend
@@ -76,6 +83,8 @@ projects:
             type: web
             runtime: docker
             plan: starter
+            previews:
+              plan: starter
             region: ohio
             dockerfilePath: ./Dockerfile
             autoDeployTrigger: checksPass
@@ -122,6 +131,8 @@ projects:
             type: worker
             runtime: docker
             plan: starter
+            previews:
+              plan: starter
             region: ohio
             dockerfilePath: ./Dockerfile
             autoDeployTrigger: checksPass
@@ -140,6 +151,8 @@ projects:
             type: cron
             runtime: docker
             plan: starter
+            previews:
+              generation: off
             region: ohio
             dockerfilePath: ./Dockerfile
             autoDeployTrigger: checksPass
@@ -157,6 +170,8 @@ projects:
             type: cron
             runtime: docker
             plan: starter
+            previews:
+              generation: off
             region: ohio
             dockerfilePath: ./Dockerfile
             autoDeployTrigger: checksPass

--- a/render.yaml
+++ b/render.yaml
@@ -82,6 +82,9 @@ projects:
               - key: RENDER_SECRETS_ENV_FILE
                 value: /etc/secrets/secrets.env
                 previewValue: /etc/secrets/staging.secrets.env
+              - key: DB_SEED
+                value: "false"
+                previewValue: "true"
 
         services:
           - name: davidhartingdotcom-web

--- a/render.yaml
+++ b/render.yaml
@@ -106,7 +106,6 @@ projects:
             healthCheckPath: /healthz
             domains:
               - davidharting.com
-            renderSubdomainPolicy: disabled
             # --caddyfile=Caddyfile is kept because without it Octane generates its own
             # stub Caddyfile and we lose the FrankenPHP worker config, body-size limit,
             # encode, and log redaction. $PORT is substituted inside the Caddyfile via

--- a/render.yaml
+++ b/render.yaml
@@ -77,8 +77,7 @@ projects:
 
               # Secrets are mounted as secret files and linked to /app/.env by
               # scripts/render-with-secrets.sh at runtime. Production loads
-              # secrets.env; preview environments load staging.env (different
-              # R2 credentials/buckets and Telegram bot token).
+              # secrets.env; preview environments load staging.secrets.env.
               - key: RENDER_SECRETS_ENV_FILE
                 value: /etc/secrets/secrets.env
                 previewValue: /etc/secrets/staging.secrets.env

--- a/scripts/predeploy.sh
+++ b/scripts/predeploy.sh
@@ -4,6 +4,7 @@ set -e
 php artisan migrate --force
 if [[ "${IS_PULL_REQUEST:-false}" == "true" ]]; then
     WEBHOOK_BASE="${RENDER_EXTERNAL_URL}"
+    php artisan db:seed --force
 else
     WEBHOOK_BASE="${APP_URL}"
 fi

--- a/scripts/predeploy.sh
+++ b/scripts/predeploy.sh
@@ -2,5 +2,10 @@
 set -e
 
 php artisan migrate --force
-php artisan nutgram:hook:set "$APP_URL/api/telegram/webhook"
+if [[ "${IS_PULL_REQUEST:-false}" == "true" ]]; then
+    WEBHOOK_BASE="${RENDER_EXTERNAL_URL}"
+else
+    WEBHOOK_BASE="${APP_URL}"
+fi
+php artisan nutgram:hook:set "$WEBHOOK_BASE/api/telegram/webhook"
 php artisan nutgram:register-commands

--- a/scripts/predeploy.sh
+++ b/scripts/predeploy.sh
@@ -4,7 +4,9 @@ set -e
 php artisan migrate --force
 if [[ "${IS_PULL_REQUEST:-false}" == "true" ]]; then
     WEBHOOK_BASE="${RENDER_EXTERNAL_URL}"
-    php artisan db:seed --force
+    # Only seed on the first deploy of this PR (DB persists across pushes).
+    # exit(0) = users exist = already seeded; exit(1) = empty = seed now.
+    php artisan tinker --execute='exit(\App\Models\User::count() > 0 ? 0 : 1);' > /dev/null 2>&1 || php artisan db:seed --force
 else
     WEBHOOK_BASE="${APP_URL}"
 fi

--- a/scripts/predeploy.sh
+++ b/scripts/predeploy.sh
@@ -4,9 +4,6 @@ set -e
 php artisan migrate --force
 if [[ "${IS_PULL_REQUEST:-false}" == "true" ]]; then
     WEBHOOK_BASE="${RENDER_EXTERNAL_URL}"
-    # Only seed on the first deploy of this PR (DB persists across pushes).
-    # exit(0) = users exist = already seeded; exit(1) = empty = seed now.
-    php artisan tinker --execute='exit(\App\Models\User::count() > 0 ? 0 : 1);' > /dev/null 2>&1 || php artisan db:seed --force
 else
     WEBHOOK_BASE="${APP_URL}"
 fi

--- a/scripts/seed.sh
+++ b/scripts/seed.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [[ "${RUN_DEV_SEEDER:-false}" != "true" ]]; then
+    echo "RUN_DEV_SEEDER is not true, skipping seed."
+    exit 0
+fi
+
+php artisan db:seed --force


### PR DESCRIPTION
### What changed

Enables automatic Render preview environments for every pull request — each PR gets ephemeral web and worker services with their own Postgres database, staging R2 buckets, and a staging Telegram bot.

- Backup cron jobs excluded from previews (`generation: off`) — no value in running hourly/daily backups against a throwaway database
- Preview environments auto-expire after 2 days of inactivity
- All preview services use `starter` plan; database uses `basic-256mb`
- `predeploy.sh` now uses `RENDER_EXTERNAL_URL` when `IS_PULL_REQUEST=true` so the Telegram webhook registers to the actual preview URL, not `davidharting.com`
- Preview services load `/etc/secrets/staging.secrets.env` instead of `secrets.env` via `RENDER_SECRETS_ENV_FILE`, giving them isolated R2 credentials and a staging Telegram bot token

### Why

PR environments let us test changes against a real stack (real DB, real queues, real file storage) before merging, without touching production.

### Demo

N/A — infrastructure change only.

---

_Generated by [Claude Code](https://docs.anthropic.com/en/docs/claude-code)_