### PR TITLE
Validate PR preview environment provisioning

### DIFF
--- a/resources/views/components/layout/app.blade.php
+++ b/resources/views/components/layout/app.blade.php
@@ -38,6 +38,12 @@
     </head>
 
     <body class="font-serif antialiased">
+        @if (env("IS_PULL_REQUEST"))
+            <div role="alert" class="alert alert-warning rounded-none">
+                <span>PR Preview &mdash; {{ config("app.url") }}</span>
+            </div>
+        @endif
+
         <div class="container mx-auto px-4">
             <main class="mt-8">
                 <div class="flex justify-between w-full mb-8">

--- a/routes/telegram.php
+++ b/routes/telegram.php
@@ -18,7 +18,10 @@ use SergiX44\Nutgram\Nutgram;
 */
 
 $bot->onCommand('example', function (Nutgram $bot) {
-    $bot->sendMessage('Hello, world!');
+    $url = config('app.url');
+    $env = config('app.env');
+    $isPr = env('IS_PULL_REQUEST', false) ? 'yes' : 'no';
+    $bot->sendMessage("Hello! APP_URL={$url} APP_ENV={$env} IS_PULL_REQUEST={$isPr}");
 })->description('An example command')->middleware(OnlyDavidMiddleware::class);
 
 $bot->registerCommand(WhoamiCommand::class);

--- a/tests/Feature/Telegram/ExampleCommandTest.php
+++ b/tests/Feature/Telegram/ExampleCommandTest.php
@@ -3,8 +3,10 @@
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\Telegram\Types\User\User;
 use SergiX44\Nutgram\Testing\FakeNutgram;
+use Tests\TestCase;
 
-test('example command replies with hello world', function () {
+test('example command replies with environment info', function () {
+    /** @var TestCase $this */
     /** @var FakeNutgram $bot */
     $bot = app(Nutgram::class);
     $bot->setCommonUser(User::make(
@@ -13,9 +15,12 @@ test('example command replies with hello world', function () {
         first_name: 'David',
     ));
 
+    $url = config('app.url');
+    $env = config('app.env');
+
     $bot->hearText('/example')
         ->reply()
-        ->assertReplyText('Hello, world!');
+        ->assertReplyText("Hello! APP_URL={$url} APP_ENV={$env} IS_PULL_REQUEST=no");
 });
 
 test('unauthorized user is rejected from example command', function () {


### PR DESCRIPTION
## Purpose

This PR is **not meant to be merged**. It exists solely to validate that Render PR preview environments are provisioned, seeded, and functional.

## What changed

**UI — PR environment banner** (`resources/views/components/layout/app.blade.php`)

Adds a full-width DaisyUI warning alert at the top of every page when the `IS_PULL_REQUEST` env var is set (Render injects this automatically for preview environments). The banner displays the `APP_URL`, making it immediately obvious which environment you're browsing.

**Telegram `/example` command** (`routes/telegram.php`)

The `/example` bot command now replies with:
```
Hello! APP_URL=<url> APP_ENV=<env> IS_PULL_REQUEST=<yes|no>
```
Use this to confirm from the bot that the preview environment is responding and that the right values are injected.

## How to validate

1. Wait for Render to provision the PR preview URL
2. Open the preview URL — you should see the yellow "PR Preview — https://..." banner at the top
3. Send `/example` to the Telegram bot pointed at the preview — it should reply with the preview URL and `IS_PULL_REQUEST=yes`
4. Confirm the database was seeded (log in, check that seed data is present)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLQPhtYeSRkqDmACcXvYnq)_