### PR TITLE
Fix PR preview seed failure: move fakerphp/faker to production deps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,16 @@ Operational notes:
 - The web service `preDeployCommand` runs migrations and Telegram webhook registration before new web instances receive traffic.
 - Historical note: this previously ran on a Digital Ocean droplet with Docker Compose. See `docs/projects/render-migration.md` for migration history.
 
+### PR preview environments
+
+`render.yaml` has `previews.generation: automatic`, so every PR gets its own preview environment (web + worker; the cron jobs are excluded via `previews.generation: off`). The web service's preview URL is always:
+
+```
+https://davidhartingdotcom-web-pr-<PR_NUMBER>.onrender.com
+```
+
+e.g. PR #155 -> `https://davidhartingdotcom-web-pr-155.onrender.com`. Preview environments set `IS_PULL_REQUEST=true` and `RUN_DEV_SEEDER=true`, and use the staging secrets/env group rather than production.
+
 ## Commands
 
 - Use `ripgrep` to search files and `fd` to find files

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "php": "^8.1",
         "filament/filament": "^5.0",
         "filament/infolists": "^5.0",
+        "fakerphp/faker": "^1.24.1",
         "guzzlehttp/guzzle": "^7.9.2",
         "laravel/ai": "^0.4.2",
         "laravel/breeze": "^2.3.5",
@@ -29,7 +30,6 @@
         "spatie/laravel-markdown-response": "^1.1"
     },
     "require-dev": {
-        "fakerphp/faker": "^1.24.1",
         "laravel/pint": "^1.29",
         "laravel/sail": "^1.41",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b8e8a5d139eed0f1b69db323084c37f",
+    "content-hash": "13ccbdbeb30e19ddaa3aba2ebdd7f1fb",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -1271,6 +1271,69 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "fakerphp/faker",
+            "version": "v1.24.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.5.26",
+                "symfony/phpunit-bridge": "^5.4.16"
+            },
+            "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
+            },
+            "time": "2024-11-21T13:46:39+00:00"
         },
         {
             "name": "filament/actions",
@@ -11007,69 +11070,6 @@
                 "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
             },
             "time": "2025-04-07T20:06:18+00:00"
-        },
-        {
-            "name": "fakerphp/faker",
-            "version": "v1.24.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/FakerPHP/Faker.git",
-                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
-                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0",
-                "psr/container": "^1.0 || ^2.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
-            },
-            "conflict": {
-                "fzaninotto/faker": "*"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.4.1",
-                "doctrine/persistence": "^1.3 || ^2.0",
-                "ext-intl": "*",
-                "phpunit/phpunit": "^9.5.26",
-                "symfony/phpunit-bridge": "^5.4.16"
-            },
-            "suggest": {
-                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
-                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
-                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
-                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
-                "ext-mbstring": "Required for multibyte Unicode string functionality."
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Faker\\": "src/Faker/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "François Zaninotto"
-                }
-            ],
-            "description": "Faker is a PHP library that generates fake data for you.",
-            "keywords": [
-                "data",
-                "faker",
-                "fixtures"
-            ],
-            "support": {
-                "issues": "https://github.com/FakerPHP/Faker/issues",
-                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
-            },
-            "time": "2024-11-21T13:46:39+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
## Purpose

PR #155 (the PR preview environment validation PR) surfaced a real bug: the preview environment's `initialDeployHook` (which runs the seed script) failed with:

```
Call to undefined function Database\Factories\fake()
```

The web service itself deployed and went `live` fine — only the post-deploy seed step failed, which is why the Blueprint showed a failed sync even though everything looked healthy.

## Root cause

`fakerphp/faker` was listed under `require-dev` in `composer.json`. The Dockerfile builds with `composer install --no-dev` (`Dockerfile:51`), so Faker was stripped from the image. Preview environments set `RUN_DEV_SEEDER=true`, so `scripts/seed.sh` runs `php artisan db:seed --force`, which calls `User::factory()->create()` → `UserFactory::definition()` → `fake()`. Without the Faker package installed, that helper doesn't exist.

## Fix

- Moved `fakerphp/faker` from `require-dev` to `require` in `composer.json`, and regenerated `composer.lock` (`composer update fakerphp/faker`) so it's installed in production/preview builds. This is the standard approach when a seeder needs `fake()` outside `local`/testing — Faker has no heavy transitive dependencies, so this isn't meaningful bloat.
- Documented how to construct a PR preview URL in `CLAUDE.md` (`https://davidhartingdotcom-web-pr-<PR_NUMBER>.onrender.com`), along with the `IS_PULL_REQUEST` / `RUN_DEV_SEEDER` env vars previews get, since `render.yaml` doesn't expose this directly.

## Test plan

- [x] `php artisan test` — all 297 tests pass
- [x] `task format` (Pint + Prettier) — clean
- [ ] Confirm the next PR preview environment seeds successfully (no `fake()` crash in the initial deploy hook logs)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLQPhtYeSRkqDmACcXvYnq)_