### PR TITLE
MCP server 3/4: extend SearchMediaQuery with status, year, sort, and pagination

### DIFF
--- a/app/Enum/MediaSort.php
+++ b/app/Enum/MediaSort.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Enum;
+
+/**
+ * Sort orders for media library queries backed by media_tracking_summary.
+ */
+enum MediaSort: string
+{
+    /** Most recently finished first; never-finished items last. */
+    case RecentlyFinished = 'recently_finished';
+
+    /** Most recently started first; never-started items last. */
+    case RecentlyStarted = 'recently_started';
+
+    /**
+     * Most recently added to the library first. The view does not expose
+     * created_at, so this orders by media_id, which increases monotonically.
+     */
+    case RecentlyAdded = 'recently_added';
+
+    /** Alphabetical by title. */
+    case Title = 'title';
+
+    /** Release year, most recent first. */
+    case Year = 'year';
+}

--- a/app/Enum/MediaSort.php
+++ b/app/Enum/MediaSort.php
@@ -4,6 +4,10 @@ namespace App\Enum;
 
 /**
  * Sort orders for media library queries backed by media_tracking_summary.
+ *
+ * Every sort ends with a media_id (library insertion order) tiebreaker, so
+ * ordering is fully deterministic: items a sort cannot rank — e.g.
+ * never-finished items under RecentlyFinished — come last, oldest first.
  */
 enum MediaSort: string
 {
@@ -21,6 +25,9 @@ enum MediaSort: string
 
     /** Alphabetical by title. */
     case Title = 'title';
+
+    /** Alphabetical by creator name. */
+    case Creator = 'creator';
 
     /** Release year, most recent first. */
     case Year = 'year';

--- a/app/Enum/MediaTrackingStatus.php
+++ b/app/Enum/MediaTrackingStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enum;
+
+/**
+ * The derived tracking status of a media item, as computed by the
+ * media_tracking_summary view's current_status column. Unlike
+ * MediaEventTypeName this includes Backlog, the status of an item
+ * with no started/finished/abandoned events.
+ */
+enum MediaTrackingStatus: string
+{
+    case Backlog = 'backlog';
+    case Started = 'started';
+    case Finished = 'finished';
+    case Abandoned = 'abandoned';
+}

--- a/app/Queries/Media/SearchMediaQuery.php
+++ b/app/Queries/Media/SearchMediaQuery.php
@@ -102,15 +102,12 @@ class SearchMediaQuery
      */
     private function applySort(Builder $query): void
     {
-        if ($this->sort === null) {
-            return;
-        }
-
-        match ($this->sort) {
+        match ($this->sort ?? MediaSort::RecentlyAdded) {
             MediaSort::RecentlyFinished => $query->orderByRaw('finished_at desc nulls last'),
             MediaSort::RecentlyStarted => $query->orderByRaw('started_at desc nulls last'),
             MediaSort::RecentlyAdded => $query->orderByDesc('media_id'),
             MediaSort::Title => $query->orderBy('title'),
+            MediaSort::Creator => $query->orderBy('creator'),
             MediaSort::Year => $query->orderByRaw('year desc nulls last'),
         };
 

--- a/app/Queries/Media/SearchMediaQuery.php
+++ b/app/Queries/Media/SearchMediaQuery.php
@@ -2,23 +2,65 @@
 
 namespace App\Queries\Media;
 
+use App\Enum\MediaSort;
+use App\Enum\MediaTrackingStatus;
 use App\Enum\MediaTypeName;
 use App\Models\MediaTrackingSummary;
 use App\Support\LikePattern;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
 class SearchMediaQuery
 {
+    private const COLUMNS = [
+        'media_id',
+        'creator_id',
+        'title',
+        'year',
+        'media_type',
+        'creator',
+        'current_status',
+        'started_at',
+        'finished_at',
+        'abandoned_at',
+    ];
+
     public function __construct(
         public ?string $title = null,
         public ?MediaTypeName $mediaType = null,
         public ?string $creator = null,
+        public ?MediaTrackingStatus $status = null,
+        public ?int $year = null,
+        public ?int $startedYear = null,
+        public ?int $finishedYear = null,
+        public ?MediaSort $sort = null,
     ) {}
 
     /**
      * @return Collection<int, MediaTrackingSummary>
      */
     public function execute(): Collection
+    {
+        return $this->builder()->get(self::COLUMNS);
+    }
+
+    /**
+     * @return LengthAwarePaginator<int, MediaTrackingSummary>
+     */
+    public function paginate(int $perPage, int $page): LengthAwarePaginator
+    {
+        return $this->builder()->paginate(
+            perPage: $perPage,
+            columns: self::COLUMNS,
+            page: $page,
+        );
+    }
+
+    /**
+     * @return Builder<MediaTrackingSummary>
+     */
+    private function builder(): Builder
     {
         $query = MediaTrackingSummary::query();
 
@@ -34,17 +76,45 @@ class SearchMediaQuery
             $query->where('media_type', $this->mediaType->value);
         }
 
-        return $query->get([
-            'media_id',
-            'creator_id',
-            'title',
-            'year',
-            'media_type',
-            'creator',
-            'current_status',
-            'started_at',
-            'finished_at',
-            'abandoned_at',
-        ]);
+        if ($this->status !== null) {
+            $query->where('current_status', $this->status->value);
+        }
+
+        if ($this->year !== null) {
+            $query->where('year', $this->year);
+        }
+
+        if ($this->startedYear !== null) {
+            $query->whereYear('started_at', $this->startedYear);
+        }
+
+        if ($this->finishedYear !== null) {
+            $query->whereYear('finished_at', $this->finishedYear);
+        }
+
+        $this->applySort($query);
+
+        return $query;
+    }
+
+    /**
+     * @param  Builder<MediaTrackingSummary>  $query
+     */
+    private function applySort(Builder $query): void
+    {
+        if ($this->sort === null) {
+            return;
+        }
+
+        match ($this->sort) {
+            MediaSort::RecentlyFinished => $query->orderByRaw('finished_at desc nulls last'),
+            MediaSort::RecentlyStarted => $query->orderByRaw('started_at desc nulls last'),
+            MediaSort::RecentlyAdded => $query->orderByDesc('media_id'),
+            MediaSort::Title => $query->orderBy('title'),
+            MediaSort::Year => $query->orderByRaw('year desc nulls last'),
+        };
+
+        // Deterministic tiebreaker so paginated pages never overlap.
+        $query->orderBy('media_id');
     }
 }

--- a/tests/Feature/Queries/Media/SearchMediaQueryTest.php
+++ b/tests/Feature/Queries/Media/SearchMediaQueryTest.php
@@ -428,6 +428,28 @@ describe('sort', function () {
         $this->assertSame(['Aardvark', 'Zebra'], $titles);
     });
 
+    test('creator sorts alphabetically by creator name', function () {
+        /** @var TestCase $this */
+        $smith = Creator::factory()->create(['name' => 'Zadie Smith']);
+        $patchett = Creator::factory()->create(['name' => 'Ann Patchett']);
+        Media::factory()->book()->create(['title' => 'By Zadie', 'creator_id' => $smith->id]);
+        Media::factory()->book()->create(['title' => 'By Ann', 'creator_id' => $patchett->id]);
+
+        $titles = (new SearchMediaQuery(sort: MediaSort::Creator))->execute()->pluck('title')->all();
+
+        $this->assertSame(['By Ann', 'By Zadie'], $titles);
+    });
+
+    test('defaults to most recently added first when no sort is given', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->create(['title' => 'Added First']);
+        Media::factory()->book()->create(['title' => 'Added Second']);
+
+        $titles = (new SearchMediaQuery)->execute()->pluck('title')->all();
+
+        $this->assertSame(['Added Second', 'Added First'], $titles);
+    });
+
     test('year puts the most recent releases first', function () {
         /** @var TestCase $this */
         Media::factory()->book()->create(['title' => 'Old Release', 'year' => 1965]);

--- a/tests/Feature/Queries/Media/SearchMediaQueryTest.php
+++ b/tests/Feature/Queries/Media/SearchMediaQueryTest.php
@@ -1,11 +1,14 @@
 <?php
 
+use App\Enum\MediaSort;
+use App\Enum\MediaTrackingStatus;
 use App\Enum\MediaTypeName;
 use App\Models\Creator;
 use App\Models\Media;
 use App\Models\MediaEvent;
 use App\Queries\Media\SearchMediaQuery;
 use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\Support\Carbon;
 
 test('returns empty collection when no media matches', function () {
     /** @var TestCase $this */
@@ -245,5 +248,228 @@ describe('status', function () {
         $item = (new SearchMediaQuery(title: 'Neuromancer'))->execute()->sole();
 
         $this->assertSame('started', $item->current_status);
+    });
+});
+
+describe('status filter', function () {
+    test('filters by backlog status', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->create(['title' => 'Untouched Book']);
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->started(), 'events')
+            ->create(['title' => 'Started Book']);
+
+        $results = (new SearchMediaQuery(status: MediaTrackingStatus::Backlog))->execute();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Untouched Book', $results->sole()->title);
+    });
+
+    test('filters by started status', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->create(['title' => 'Untouched Book']);
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->started(), 'events')
+            ->create(['title' => 'Started Book']);
+
+        $results = (new SearchMediaQuery(status: MediaTrackingStatus::Started))->execute();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Started Book', $results->sole()->title);
+    });
+
+    test('filters by finished status', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->started()->at(now()->subDays(2)), 'events')
+            ->has(MediaEvent::factory()->finished()->at(now()), 'events')
+            ->create(['title' => 'Finished Book']);
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->started()->at(now()->subDays(2)), 'events')
+            ->has(MediaEvent::factory()->abandoned()->at(now()), 'events')
+            ->create(['title' => 'Abandoned Book']);
+
+        $results = (new SearchMediaQuery(status: MediaTrackingStatus::Finished))->execute();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Finished Book', $results->sole()->title);
+    });
+
+    test('filters by abandoned status', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->started()->at(now()->subDays(2)), 'events')
+            ->has(MediaEvent::factory()->finished()->at(now()), 'events')
+            ->create(['title' => 'Finished Book']);
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->started()->at(now()->subDays(2)), 'events')
+            ->has(MediaEvent::factory()->abandoned()->at(now()), 'events')
+            ->create(['title' => 'Abandoned Book']);
+
+        $results = (new SearchMediaQuery(status: MediaTrackingStatus::Abandoned))->execute();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Abandoned Book', $results->sole()->title);
+    });
+});
+
+describe('year filters', function () {
+    test('filters by release year', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->create(['title' => 'Old Book', 'year' => 1965]);
+        Media::factory()->book()->create(['title' => 'New Book', 'year' => 2020]);
+
+        $results = (new SearchMediaQuery(year: 1965))->execute();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Old Book', $results->sole()->title);
+    });
+
+    test('filters by started year', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->started()->at(Carbon::create(2023, 5, 1)), 'events')
+            ->create(['title' => 'Started In 2023']);
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->started()->at(Carbon::create(2024, 5, 1)), 'events')
+            ->create(['title' => 'Started In 2024']);
+
+        $results = (new SearchMediaQuery(startedYear: 2023))->execute();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Started In 2023', $results->sole()->title);
+    });
+
+    test('filters by finished year', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->finished()->at(Carbon::create(2023, 5, 1)), 'events')
+            ->create(['title' => 'Finished In 2023']);
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->finished()->at(Carbon::create(2024, 5, 1)), 'events')
+            ->create(['title' => 'Finished In 2024']);
+
+        $results = (new SearchMediaQuery(finishedYear: 2023))->execute();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Finished In 2023', $results->sole()->title);
+    });
+
+    test('release year is distinct from finished year', function () {
+        /** @var TestCase $this */
+        // A 1965 book finished in 2024: matches year=1965 and finishedYear=2024,
+        // but not year=2024.
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->finished()->at(Carbon::create(2024, 5, 1)), 'events')
+            ->create(['title' => 'Dune', 'year' => 1965]);
+
+        $this->assertCount(1, (new SearchMediaQuery(year: 1965))->execute());
+        $this->assertCount(1, (new SearchMediaQuery(finishedYear: 2024))->execute());
+        $this->assertEmpty((new SearchMediaQuery(year: 2024))->execute());
+    });
+
+    test('items without events are excluded by event-year filters', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->create(['title' => 'Backlog Book']);
+
+        $this->assertEmpty((new SearchMediaQuery(startedYear: 2024))->execute());
+        $this->assertEmpty((new SearchMediaQuery(finishedYear: 2024))->execute());
+    });
+});
+
+describe('sort', function () {
+    test('recently_finished puts most recently finished first and unfinished last', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->finished()->at(Carbon::create(2023, 1, 1)), 'events')
+            ->create(['title' => 'Finished Earlier']);
+        Media::factory()->book()->create(['title' => 'Never Finished']);
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->finished()->at(Carbon::create(2024, 1, 1)), 'events')
+            ->create(['title' => 'Finished Recently']);
+
+        $titles = (new SearchMediaQuery(sort: MediaSort::RecentlyFinished))->execute()->pluck('title')->all();
+
+        $this->assertSame(['Finished Recently', 'Finished Earlier', 'Never Finished'], $titles);
+    });
+
+    test('recently_started puts most recently started first and unstarted last', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->started()->at(Carbon::create(2023, 1, 1)), 'events')
+            ->create(['title' => 'Started Earlier']);
+        Media::factory()->book()->create(['title' => 'Never Started']);
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->started()->at(Carbon::create(2024, 1, 1)), 'events')
+            ->create(['title' => 'Started Recently']);
+
+        $titles = (new SearchMediaQuery(sort: MediaSort::RecentlyStarted))->execute()->pluck('title')->all();
+
+        $this->assertSame(['Started Recently', 'Started Earlier', 'Never Started'], $titles);
+    });
+
+    test('recently_added puts the newest library entries first', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->create(['title' => 'Added First']);
+        Media::factory()->book()->create(['title' => 'Added Second']);
+
+        $titles = (new SearchMediaQuery(sort: MediaSort::RecentlyAdded))->execute()->pluck('title')->all();
+
+        $this->assertSame(['Added Second', 'Added First'], $titles);
+    });
+
+    test('title sorts alphabetically', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->create(['title' => 'Zebra']);
+        Media::factory()->book()->create(['title' => 'Aardvark']);
+
+        $titles = (new SearchMediaQuery(sort: MediaSort::Title))->execute()->pluck('title')->all();
+
+        $this->assertSame(['Aardvark', 'Zebra'], $titles);
+    });
+
+    test('year puts the most recent releases first', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->create(['title' => 'Old Release', 'year' => 1965]);
+        Media::factory()->book()->create(['title' => 'New Release', 'year' => 2020]);
+
+        $titles = (new SearchMediaQuery(sort: MediaSort::Year))->execute()->pluck('title')->all();
+
+        $this->assertSame(['New Release', 'Old Release'], $titles);
+    });
+});
+
+describe('paginate()', function () {
+    test('returns the requested page with the total count', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->count(3)->create();
+
+        $paginator = (new SearchMediaQuery(sort: MediaSort::RecentlyAdded))->paginate(perPage: 2, page: 2);
+
+        $this->assertSame(3, $paginator->total());
+        $this->assertSame(2, $paginator->currentPage());
+        $this->assertCount(1, $paginator->items());
+    });
+
+    test('applies filters', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->create(['title' => 'Dune']);
+        Media::factory()->book()->create(['title' => 'Foundation']);
+
+        $paginator = (new SearchMediaQuery(title: 'Dune'))->paginate(perPage: 10, page: 1);
+
+        $this->assertSame(1, $paginator->total());
+    });
+
+    test('pages never overlap when sorted', function () {
+        /** @var TestCase $this */
+        // Identical titles force the sort to fall through to the tiebreaker.
+        Media::factory()->book()->count(4)->create(['title' => 'Same Title']);
+
+        $query = new SearchMediaQuery(sort: MediaSort::Title);
+        $firstPage = collect($query->paginate(perPage: 2, page: 1)->items())->pluck('media_id');
+        $secondPage = collect($query->paginate(perPage: 2, page: 2)->items())->pluck('media_id');
+
+        $this->assertCount(4, $firstPage->merge($secondPage)->unique());
     });
 });


### PR DESCRIPTION
Implements step 4 of [docs/projects/mcp-server.md](docs/projects/mcp-server.md). Stacked on #165.

## What

Extends the shared `SearchMediaQuery` object instead of writing a parallel query class, per the plan. All new constructor parameters default to null/off, so the existing Telegram agent tool (`App\Ai\Tools\SearchMedia`) is unaffected — and gets the richer query for free.

- **`status`** — filter on the view's derived `current_status`, via a new `MediaTrackingStatus` enum (backlog / started / finished / abandoned).
- **`year` / `startedYear` / `finishedYear`** — release year vs. year an item was started/finished (extracted from the view's timestamps, matching how the site's logbook year filter works).
- **`sort`** — new `MediaSort` enum: `recently_finished`, `recently_started`, `recently_added`, `title`, `year`. Timestamp sorts use `NULLS LAST` so never-finished items don't lead the list, and every sort gets a `media_id` tiebreaker so paginated pages never overlap. `recently_added` orders by `media_id` since the view doesn't expose `created_at`.
- **`paginate(perPage, page)`** — `LengthAwarePaginator` with the same filters/columns as `execute()`, for the `QueryMedia` tool in the next PR which needs totals and bounded pages.

## Tests

Extends the existing `SearchMediaQueryTest` with describe blocks for each new capability: every status, all three year filters (including the release-year vs. finished-year distinction), every sort order (including null-timestamp placement), and pagination (totals, filters, no page overlap under a tied sort).

## Stack

1. #164: dependency + server skeleton + transport test
2. #165: notes tools
3. **→ this PR**: `SearchMediaQuery` extension
4. `QueryMedia` tool + instructions polish + docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hCo82mqoQ9ktERvz1kJQq

---
_Generated by [Claude Code](https://claude.ai/code/session_012hCo82mqoQ9ktERvz1kJQq)_