### PR TITLE
MCP server 4/4: QueryMedia tool, instructions polish, and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ e.g. PR #155 -> `https://davidhartingdotcom-web-pr-155.onrender.com`. Preview en
 
 ### MCP server
 
-A public, unauthenticated, read-only MCP server is served at `https://davidharting.com/mcp` (`Mcp::web()` in `routes/ai.php`, server and tools in `app/Mcp/`). It exposes published notes and the media library — only information a logged-out visitor can already see. Verify manually with `php artisan mcp:inspector mcp`. See `docs/projects/done/mcp-server.md`.
+A public, unauthenticated, read-only MCP server is served at `https://davidharting.com/mcp` (`Mcp::web()` in `routes/ai.php`, server and tools in `app/Mcp/`). It exposes published notes and the media library — only information a logged-out visitor can already see. Verify manually with `php artisan mcp:inspector mcp`. See `docs/projects/mcp-server.md`.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,10 @@ https://davidhartingdotcom-web-pr-<PR_NUMBER>.onrender.com
 
 e.g. PR #155 -> `https://davidhartingdotcom-web-pr-155.onrender.com`. Preview environments set `IS_PULL_REQUEST=true` and `RUN_DEV_SEEDER=true`, and use the staging secrets/env group rather than production.
 
+### MCP server
+
+A public, unauthenticated, read-only MCP server is served at `https://davidharting.com/mcp` (`Mcp::web()` in `routes/ai.php`, server and tools in `app/Mcp/`). It exposes published notes and the media library — only information a logged-out visitor can already see. Verify manually with `php artisan mcp:inspector mcp`. See `docs/projects/done/mcp-server.md`.
+
 ## Commands
 
 - Use `ripgrep` to search files and `fd` to find files

--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 
 My personal site, built Laravel and deployed with fly.io.
 See [davidharting.com](https://davidharting.com).
+
+AI agents can query the site's public content — published notes and the
+media library — over the Model Context Protocol at
+`https://davidharting.com/mcp`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # My personal site
 
-My personal site, built Laravel and deployed with fly.io.
-See [davidharting.com](https://davidharting.com).
+[davidharting.com](https://davidharting.com).
+
+My personal site, built with Laravel and deployed to Render.
 
 AI agents can query the site's public content — published notes and the
 media library — over the Model Context Protocol at

--- a/app/Mcp/Servers/PublicServer.php
+++ b/app/Mcp/Servers/PublicServer.php
@@ -16,7 +16,7 @@ use Laravel\Mcp\Server\Attributes\Version;
  * The name is the contract: every tool registered here must only ever return
  * information that is already visible to a logged-out visitor on the website.
  * Authenticated capabilities belong on a separate server, never here (see
- * docs/projects/done/mcp-server.md).
+ * docs/projects/mcp-server.md).
  */
 #[Name('davidharting.com')]
 #[Version('1.0.0')]

--- a/app/Mcp/Servers/PublicServer.php
+++ b/app/Mcp/Servers/PublicServer.php
@@ -7,7 +7,6 @@ use App\Mcp\Tools\ListNotes;
 use App\Mcp\Tools\QueryMedia;
 use App\Mcp\Tools\SearchNotes;
 use Laravel\Mcp\Server;
-use Laravel\Mcp\Server\Attributes\Instructions;
 use Laravel\Mcp\Server\Attributes\Name;
 use Laravel\Mcp\Server\Attributes\Version;
 
@@ -17,13 +16,30 @@ use Laravel\Mcp\Server\Attributes\Version;
  * The name is the contract: every tool registered here must only ever return
  * information that is already visible to a logged-out visitor on the website.
  * Authenticated capabilities belong on a separate server, never here (see
- * docs/projects/mcp-server.md).
+ * docs/projects/done/mcp-server.md).
  */
 #[Name('davidharting.com')]
 #[Version('1.0.0')]
-#[Instructions('This server exposes the public content of davidharting.com, the personal website of David Harting: published notes (blog posts) and his media tracking library. All data available here is public — the same information a logged-out visitor sees on the website.')]
 class PublicServer extends Server
 {
+    protected string $instructions = <<<'MARKDOWN'
+        This server exposes the public content of davidharting.com, the personal
+        website of David Harting. Everything available here is public — the same
+        information a logged-out visitor sees on the website. There are two kinds
+        of content:
+
+        **Notes** are David's blog posts. Use list-notes to browse them
+        (newest first), search-notes to find notes matching a query, and
+        get-note to read one in full as markdown.
+
+        **The media library** tracks the albums, books, movies, TV shows, and
+        video games David engages with. Each item has a current status —
+        backlog (not started), started, finished, or abandoned — plus the dates
+        those statuses were reached. Use query-media to filter by any
+        combination of title, creator, media type, status, release year, and
+        the year an item was started or finished.
+        MARKDOWN;
+
     protected array $tools = [
         ListNotes::class,
         SearchNotes::class,

--- a/app/Mcp/Servers/PublicServer.php
+++ b/app/Mcp/Servers/PublicServer.php
@@ -4,6 +4,7 @@ namespace App\Mcp\Servers;
 
 use App\Mcp\Tools\GetNote;
 use App\Mcp\Tools\ListNotes;
+use App\Mcp\Tools\QueryMedia;
 use App\Mcp\Tools\SearchNotes;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Attributes\Instructions;
@@ -27,6 +28,7 @@ class PublicServer extends Server
         ListNotes::class,
         SearchNotes::class,
         GetNote::class,
+        QueryMedia::class,
     ];
 
     protected array $resources = [

--- a/app/Mcp/Tools/QueryMedia.php
+++ b/app/Mcp/Tools/QueryMedia.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Enum\MediaSort;
+use App\Enum\MediaTrackingStatus;
+use App\Enum\MediaTypeName;
+use App\Models\MediaTrackingSummary;
+use App\Queries\Media\SearchMediaQuery;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\Rule;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[IsIdempotent]
+#[Description(<<<'TEXT'
+    Query David Harting's media tracking library: the albums, books, movies, TV
+    shows, and video games he tracks, with their current status (backlog,
+    started, finished, or abandoned) and the dates each status was reached. All
+    filters are optional and combine with AND; with no arguments the whole
+    library is returned, paginated. Examples: everything finished in 2025
+    (status=finished, finished_year=2025); books in the backlog
+    (media_type=book, status=backlog); anything by a given creator
+    (creator=FromSoftware); what is being read right now (media_type=book,
+    status=started). Note the difference between year (the work's release
+    year) and started_year / finished_year (when David started or finished
+    it).
+    TEXT)]
+class QueryMedia extends Tool
+{
+    /**
+     * Handle the tool request.
+     */
+    public function handle(Request $request): ResponseFactory
+    {
+        $validated = $request->validate([
+            'title' => ['sometimes', 'string'],
+            'creator' => ['sometimes', 'string'],
+            'media_type' => ['sometimes', 'string', Rule::enum(MediaTypeName::class)],
+            'status' => ['sometimes', 'string', Rule::enum(MediaTrackingStatus::class)],
+            'year' => ['sometimes', 'integer'],
+            'started_year' => ['sometimes', 'integer'],
+            'finished_year' => ['sometimes', 'integer'],
+            'sort' => ['sometimes', 'string', Rule::enum(MediaSort::class)],
+            'page' => ['sometimes', 'integer', 'min:1'],
+            'limit' => ['sometimes', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        $status = isset($validated['status'])
+            ? MediaTrackingStatus::from($validated['status'])
+            : null;
+
+        $query = new SearchMediaQuery(
+            title: $validated['title'] ?? null,
+            mediaType: isset($validated['media_type']) ? MediaTypeName::from($validated['media_type']) : null,
+            creator: $validated['creator'] ?? null,
+            status: $status,
+            year: $validated['year'] ?? null,
+            startedYear: $validated['started_year'] ?? null,
+            finishedYear: $validated['finished_year'] ?? null,
+            sort: isset($validated['sort'])
+                ? MediaSort::from($validated['sort'])
+                : $this->defaultSort($status),
+        );
+
+        $paginator = $query->paginate(
+            perPage: $validated['limit'] ?? 25,
+            page: $validated['page'] ?? 1,
+        );
+
+        return Response::structured([
+            'results' => collect($paginator->items())->map(fn (MediaTrackingSummary $item): array => [
+                'media_id' => $item->media_id,
+                'title' => $item->title,
+                'year' => $item->year,
+                'media_type' => $item->media_type,
+                'creator' => $item->creator,
+                'current_status' => $item->current_status,
+                'started_at' => $item->started_at?->toIso8601String(),
+                'finished_at' => $item->finished_at?->toIso8601String(),
+                'abandoned_at' => $item->abandoned_at?->toIso8601String(),
+            ])->all(),
+            'total' => $paginator->total(),
+            'page' => $paginator->currentPage(),
+            'limit' => $paginator->perPage(),
+            'has_more_pages' => $paginator->hasMorePages(),
+        ]);
+    }
+
+    /**
+     * When the caller does not choose a sort, pick the one they most likely
+     * mean: recently finished for finished items, recently started for
+     * started items, and newest library entries otherwise.
+     */
+    private function defaultSort(?MediaTrackingStatus $status): MediaSort
+    {
+        return match ($status) {
+            MediaTrackingStatus::Finished => MediaSort::RecentlyFinished,
+            MediaTrackingStatus::Started => MediaSort::RecentlyStarted,
+            default => MediaSort::RecentlyAdded,
+        };
+    }
+
+    /**
+     * Get the tool's input schema.
+     *
+     * @return array<string, JsonSchema>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'title' => $schema->string()
+                ->description('Match against the title (case-insensitive, partial match).'),
+            'creator' => $schema->string()
+                ->description('Match against the creator — author, director, artist, studio, etc. (case-insensitive, partial match).'),
+            'media_type' => $schema->string()
+                ->enum(array_column(MediaTypeName::cases(), 'value'))
+                ->description('Only return items of this media type.'),
+            'status' => $schema->string()
+                ->enum(array_column(MediaTrackingStatus::cases(), 'value'))
+                ->description('Only return items with this current tracking status. backlog means not yet started.'),
+            'year' => $schema->integer()
+                ->description('The release year of the work itself (e.g. the year a book was published). Distinct from started_year and finished_year.'),
+            'started_year' => $schema->integer()
+                ->description('The calendar year David started the item. Distinct from year, the release year of the work.'),
+            'finished_year' => $schema->integer()
+                ->description('The calendar year David finished the item. Distinct from year, the release year of the work.'),
+            'sort' => $schema->string()
+                ->enum(array_column(MediaSort::cases(), 'value'))
+                ->description('Sort order. Defaults to recently_finished when status=finished, recently_started when status=started, and recently_added otherwise.'),
+            'page' => $schema->integer()
+                ->min(1)
+                ->description('The page of results to return. Defaults to 1.'),
+            'limit' => $schema->integer()
+                ->min(1)
+                ->max(100)
+                ->description('How many results to return per page. Defaults to 25, maximum 100.'),
+        ];
+    }
+
+    /**
+     * Get the tool's output schema.
+     *
+     * @return array<string, JsonSchema>
+     */
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'results' => $schema->array()
+                ->items($schema->object([
+                    'media_id' => $schema->integer()->description('The internal id of the media item.'),
+                    'title' => $schema->string()->description('The title of the work.'),
+                    'year' => $schema->integer()->nullable()->description('The release year of the work.'),
+                    'media_type' => $schema->string()->description('One of: album, book, movie, tv show, video game.'),
+                    'creator' => $schema->string()->nullable()->description('The creator of the work.'),
+                    'current_status' => $schema->string()->description('One of: backlog, started, finished, abandoned.'),
+                    'started_at' => $schema->string()->nullable()->description('When David first started the item (ISO 8601), if ever.'),
+                    'finished_at' => $schema->string()->nullable()->description('When David most recently finished the item (ISO 8601), if ever.'),
+                    'abandoned_at' => $schema->string()->nullable()->description('When David most recently abandoned the item (ISO 8601), if ever.'),
+                ]))
+                ->description('The matching media items.'),
+            'total' => $schema->integer()->description('The total number of matching items across all pages.'),
+            'page' => $schema->integer()->description('The current page number.'),
+            'limit' => $schema->integer()->description('The number of results per page.'),
+            'has_more_pages' => $schema->boolean()->description('Whether more pages of results are available.'),
+        ];
+    }
+}

--- a/docs/projects/done/mcp-server.md
+++ b/docs/projects/done/mcp-server.md
@@ -1,6 +1,7 @@
 ---
 name: mcp-server
-status: planned
+description: Public, unauthenticated, read-only MCP server for notes and media queries
+status: done
 ---
 
 # Public MCP Server

--- a/docs/projects/mcp-server.md
+++ b/docs/projects/mcp-server.md
@@ -1,7 +1,7 @@
 ---
 name: mcp-server
 description: Public, unauthenticated, read-only MCP server for notes and media queries
-status: done
+status: in-progress
 ---
 
 # Public MCP Server

--- a/mise.toml
+++ b/mise.toml
@@ -58,3 +58,7 @@ run = "php artisan db:seed"
 [tasks."db:refresh"]
 description = "Drop, re-migrate, and re-seed the dev database"
 run = ["php artisan migrate:fresh", "php artisan db:seed"]
+
+[tasks.test]
+description = "Run tests for a quick dev loop"
+run = "php artisan test --compact --retry --bail"

--- a/tests/Feature/Mcp/PublicServerTest.php
+++ b/tests/Feature/Mcp/PublicServerTest.php
@@ -40,6 +40,8 @@ test('guests can initialize a session and see the server identity', function () 
 
     $response->assertOk();
     $response->assertJsonPath('result.serverInfo.name', 'davidharting.com');
+
+    expect($response->json('result.instructions'))->toContain('davidharting.com');
 });
 
 test('guests can call a tool over the streamable HTTP transport', function () {

--- a/tests/Feature/Mcp/PublicServerTest.php
+++ b/tests/Feature/Mcp/PublicServerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Note;
 use Tests\TestCase;
 
 test('guests can list tools over the streamable HTTP transport', function () {
@@ -20,6 +21,7 @@ test('guests can list tools over the streamable HTTP transport', function () {
         'list-notes',
         'search-notes',
         'get-note',
+        'query-media',
     ]);
 });
 
@@ -38,6 +40,26 @@ test('guests can initialize a session and see the server identity', function () 
 
     $response->assertOk();
     $response->assertJsonPath('result.serverInfo.name', 'davidharting.com');
+});
+
+test('guests can call a tool over the streamable HTTP transport', function () {
+    /** @var TestCase $this */
+    Note::factory()->create(['title' => 'A public note', 'visible' => true]);
+
+    $response = $this->postJson('/mcp', [
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'list-notes',
+            'arguments' => [],
+        ],
+    ]);
+
+    $response->assertOk();
+    $response->assertJsonMissingPath('error');
+    $response->assertJsonPath('result.isError', false);
+    $response->assertJsonPath('result.structuredContent.total', 1);
 });
 
 test('non-POST requests are rejected with a 405', function () {

--- a/tests/Feature/Mcp/QueryMediaTest.php
+++ b/tests/Feature/Mcp/QueryMediaTest.php
@@ -17,7 +17,7 @@ test('returns the whole library when called without arguments', function () {
 
     $response->assertOk();
     $response->assertStructuredContent(function ($json) {
-        $json->where('total', 2)->etc();
+        $json->where('total', 2)->where('has_more_pages', false)->etc();
     });
 });
 
@@ -202,12 +202,14 @@ describe('sorting', function () {
         /** @var TestCase $this */
         Media::factory()->book()->create(['title' => 'Zebra']);
         Media::factory()->book()->create(['title' => 'Aardvark']);
+        Media::factory()->book()->create(['title' => 'Monkey']);
 
         $response = PublicServer::tool(QueryMedia::class, ['sort' => 'title']);
 
         $response->assertStructuredContent(function ($json) {
             $json->where('results.0.title', 'Aardvark')
-                ->where('results.1.title', 'Zebra')
+                ->where('results.1.title', 'Monkey')
+                ->where('results.2.title', 'Zebra')
                 ->etc();
         });
     });
@@ -228,6 +230,42 @@ describe('pagination', function () {
                 ->has('results', 1)
                 ->etc();
         });
+    });
+
+    test('walking every page exhausts the full library exactly once', function () {
+        /** @var TestCase $this */
+        $created = Media::factory()->book()->count(5)->create();
+
+        $seen = [];
+        $page = 1;
+
+        do {
+            $hasMore = null;
+
+            PublicServer::tool(QueryMedia::class, ['limit' => 2, 'page' => $page])
+                ->assertOk()
+                ->assertStructuredContent(function ($json) use (&$seen, &$hasMore, $page) {
+                    $json->where('total', 5)
+                        ->where('page', $page)
+                        ->where('limit', 2)
+                        ->where('results', function ($results) use (&$seen) {
+                            $seen = array_merge($seen, $results->pluck('media_id')->all());
+
+                            return true;
+                        })
+                        ->where('has_more_pages', function ($value) use (&$hasMore) {
+                            $hasMore = $value;
+
+                            return true;
+                        })
+                        ->etc();
+                });
+
+            $page++;
+        } while ($hasMore && $page <= 5);
+
+        expect($hasMore)->toBeFalse();
+        expect($seen)->toEqualCanonicalizing($created->pluck('id')->all());
     });
 
     test('rejects a limit above the maximum', function () {

--- a/tests/Feature/Mcp/QueryMediaTest.php
+++ b/tests/Feature/Mcp/QueryMediaTest.php
@@ -1,0 +1,262 @@
+<?php
+
+use App\Mcp\Servers\PublicServer;
+use App\Mcp\Tools\QueryMedia;
+use App\Models\Creator;
+use App\Models\Media;
+use App\Models\MediaEvent;
+use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\Support\Carbon;
+
+test('returns the whole library when called without arguments', function () {
+    /** @var TestCase $this */
+    Media::factory()->book()->create(['title' => 'A Book']);
+    Media::factory()->movie()->create(['title' => 'A Movie']);
+
+    $response = PublicServer::tool(QueryMedia::class);
+
+    $response->assertOk();
+    $response->assertStructuredContent(function ($json) {
+        $json->where('total', 2)->etc();
+    });
+});
+
+test('includes the public tracking fields for each item', function () {
+    /** @var TestCase $this */
+    $creator = Creator::factory()->create(['name' => 'Frank Herbert']);
+    $media = Media::factory()->book()
+        ->has(MediaEvent::factory()->started()->at(Carbon::create(2024, 1, 5)), 'events')
+        ->has(MediaEvent::factory()->finished()->at(Carbon::create(2024, 2, 10)), 'events')
+        ->create(['title' => 'Dune', 'year' => 1965, 'creator_id' => $creator->id]);
+
+    $response = PublicServer::tool(QueryMedia::class);
+
+    $response->assertOk();
+    $response->assertStructuredContent(function ($json) use ($media) {
+        $json->where('results.0.media_id', $media->id)
+            ->where('results.0.title', 'Dune')
+            ->where('results.0.year', 1965)
+            ->where('results.0.media_type', 'book')
+            ->where('results.0.creator', 'Frank Herbert')
+            ->where('results.0.current_status', 'finished')
+            ->whereType('results.0.started_at', 'string')
+            ->whereType('results.0.finished_at', 'string')
+            ->where('results.0.abandoned_at', null)
+            ->etc();
+    });
+});
+
+describe('filters', function () {
+    test('by title', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->create(['title' => 'Dune']);
+        Media::factory()->book()->create(['title' => 'Foundation']);
+
+        $response = PublicServer::tool(QueryMedia::class, ['title' => 'dune']);
+
+        $response->assertStructuredContent(function ($json) {
+            $json->where('total', 1)->where('results.0.title', 'Dune')->etc();
+        });
+    });
+
+    test('by creator', function () {
+        /** @var TestCase $this */
+        $herbert = Creator::factory()->create(['name' => 'Frank Herbert']);
+        Media::factory()->book()->create(['title' => 'Dune', 'creator_id' => $herbert->id]);
+        Media::factory()->book()->create(['title' => 'Foundation']);
+
+        $response = PublicServer::tool(QueryMedia::class, ['creator' => 'herbert']);
+
+        $response->assertStructuredContent(function ($json) {
+            $json->where('total', 1)->where('results.0.title', 'Dune')->etc();
+        });
+    });
+
+    test('by media type', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->create(['title' => 'Dune']);
+        Media::factory()->movie()->create(['title' => 'Dune']);
+
+        $response = PublicServer::tool(QueryMedia::class, ['media_type' => 'movie']);
+
+        $response->assertStructuredContent(function ($json) {
+            $json->where('total', 1)->where('results.0.media_type', 'movie')->etc();
+        });
+    });
+
+    test('by status', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->create(['title' => 'Backlog Book']);
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->started(), 'events')
+            ->create(['title' => 'Started Book']);
+
+        $response = PublicServer::tool(QueryMedia::class, ['status' => 'backlog']);
+
+        $response->assertStructuredContent(function ($json) {
+            $json->where('total', 1)->where('results.0.title', 'Backlog Book')->etc();
+        });
+    });
+
+    test('release year is distinct from finished year', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->finished()->at(Carbon::create(2025, 3, 1)), 'events')
+            ->create(['title' => 'Dune', 'year' => 1965]);
+
+        PublicServer::tool(QueryMedia::class, ['year' => 1965])
+            ->assertStructuredContent(fn ($json) => $json->where('total', 1)->etc());
+
+        PublicServer::tool(QueryMedia::class, ['finished_year' => 2025])
+            ->assertStructuredContent(fn ($json) => $json->where('total', 1)->etc());
+
+        PublicServer::tool(QueryMedia::class, ['year' => 2025])
+            ->assertStructuredContent(fn ($json) => $json->where('total', 0)->etc());
+    });
+
+    test('by started year', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->started()->at(Carbon::create(2023, 3, 1)), 'events')
+            ->create(['title' => 'Started In 2023']);
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->started()->at(Carbon::create(2024, 3, 1)), 'events')
+            ->create(['title' => 'Started In 2024']);
+
+        $response = PublicServer::tool(QueryMedia::class, ['started_year' => 2024]);
+
+        $response->assertStructuredContent(function ($json) {
+            $json->where('total', 1)->where('results.0.title', 'Started In 2024')->etc();
+        });
+    });
+
+    test('combine with AND', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->finished()->at(Carbon::create(2025, 1, 1)), 'events')
+            ->create(['title' => 'Finished Book']);
+        Media::factory()->movie()
+            ->has(MediaEvent::factory()->finished()->at(Carbon::create(2025, 2, 1)), 'events')
+            ->create(['title' => 'Finished Movie']);
+        Media::factory()->book()->create(['title' => 'Backlog Book']);
+
+        $response = PublicServer::tool(QueryMedia::class, [
+            'media_type' => 'book',
+            'status' => 'finished',
+            'finished_year' => 2025,
+        ]);
+
+        $response->assertStructuredContent(function ($json) {
+            $json->where('total', 1)->where('results.0.title', 'Finished Book')->etc();
+        });
+    });
+});
+
+describe('privacy', function () {
+    test('never returns the admin-only note field', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->create([
+            'title' => 'A Book',
+            'note' => 'PRIVATE-NOTE-MARKER',
+        ]);
+
+        $response = PublicServer::tool(QueryMedia::class);
+
+        $response->assertOk();
+        $response->assertDontSee('PRIVATE-NOTE-MARKER');
+    });
+
+    test('never returns admin-only event comments', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->finished()->state(['comment' => 'PRIVATE-COMMENT-MARKER']), 'events')
+            ->create(['title' => 'A Book', 'note' => null]);
+
+        $response = PublicServer::tool(QueryMedia::class);
+
+        $response->assertOk();
+        $response->assertDontSee('PRIVATE-COMMENT-MARKER');
+    });
+});
+
+describe('sorting', function () {
+    test('defaults to recently finished when filtering finished items', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->finished()->at(Carbon::create(2023, 1, 1)), 'events')
+            ->create(['title' => 'Finished Earlier']);
+        Media::factory()->book()
+            ->has(MediaEvent::factory()->finished()->at(Carbon::create(2024, 1, 1)), 'events')
+            ->create(['title' => 'Finished Recently']);
+
+        $response = PublicServer::tool(QueryMedia::class, ['status' => 'finished']);
+
+        $response->assertStructuredContent(function ($json) {
+            $json->where('results.0.title', 'Finished Recently')
+                ->where('results.1.title', 'Finished Earlier')
+                ->etc();
+        });
+    });
+
+    test('honors an explicit sort', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->create(['title' => 'Zebra']);
+        Media::factory()->book()->create(['title' => 'Aardvark']);
+
+        $response = PublicServer::tool(QueryMedia::class, ['sort' => 'title']);
+
+        $response->assertStructuredContent(function ($json) {
+            $json->where('results.0.title', 'Aardvark')
+                ->where('results.1.title', 'Zebra')
+                ->etc();
+        });
+    });
+});
+
+describe('pagination', function () {
+    test('paginates results', function () {
+        /** @var TestCase $this */
+        Media::factory()->book()->count(3)->create();
+
+        $response = PublicServer::tool(QueryMedia::class, ['limit' => 2, 'page' => 2]);
+
+        $response->assertStructuredContent(function ($json) {
+            $json->where('total', 3)
+                ->where('page', 2)
+                ->where('limit', 2)
+                ->where('has_more_pages', false)
+                ->has('results', 1)
+                ->etc();
+        });
+    });
+
+    test('rejects a limit above the maximum', function () {
+        /** @var TestCase $this */
+        $response = PublicServer::tool(QueryMedia::class, ['limit' => 101]);
+
+        $response->assertHasErrors(['limit']);
+    });
+});
+
+describe('validation', function () {
+    test('rejects an invalid media type', function () {
+        /** @var TestCase $this */
+        $response = PublicServer::tool(QueryMedia::class, ['media_type' => 'podcast']);
+
+        $response->assertHasErrors(['media type']);
+    });
+
+    test('rejects an invalid status', function () {
+        /** @var TestCase $this */
+        $response = PublicServer::tool(QueryMedia::class, ['status' => 'paused']);
+
+        $response->assertHasErrors(['status']);
+    });
+
+    test('rejects an invalid sort', function () {
+        /** @var TestCase $this */
+        $response = PublicServer::tool(QueryMedia::class, ['sort' => 'random']);
+
+        $response->assertHasErrors(['sort']);
+    });
+});


### PR DESCRIPTION
Implements steps 5–6 of [docs/projects/done/mcp-server.md](docs/projects/done/mcp-server.md). Stacked on #166. Final PR in the stack.

## What

- **`QueryMedia`** — the flexible one: a single tool over `media_tracking_summary` via the extended `SearchMediaQuery`, accepting any combination of `title`, `creator`, `media_type`, `status`, `year` (release), `started_year` / `finished_year`, `sort`, and bounded pagination (default 25, max 100). No arguments = the whole library. When no sort is given it defaults to `recently_finished` for `status=finished`, `recently_started` for `status=started`, `recently_added` otherwise.
- **Instructions polish** — `PublicServer` instructions now teach agents the two content types, the media type / status vocabularies, and that everything served is public.
- **Docs** — `/mcp` pointers in CLAUDE.md and the README; the project plan moved to `docs/projects/done/` with `status: done`.

## Tests

- Every filter individually and in combination; the release-year vs. finished-year distinction.
- **Privacy pins**: the response never contains `media.note` or event `comment` values even when set on the underlying rows (the two admin-only fields called out as the main trap in the plan).
- Default and explicit sort, pagination bounds, invalid enum values.
- Transport test now exercises a guest `tools/call` over HTTP end-to-end and asserts all four tools in `tools/list`.

Full suite green: 368 passed.

## Try it

Once the preview environment is up: point an MCP client (or `php artisan mcp:inspector mcp` locally) at `https://davidhartingdotcom-web-pr-<N>.onrender.com/mcp` with seeded data.

## Stack

1. #164: dependency + server skeleton + transport test
2. #165: notes tools
3. #166: `SearchMediaQuery` extension
4. **→ this PR**: `QueryMedia` + instructions + docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hCo82mqoQ9ktERvz1kJQq

---
_Generated by [Claude Code](https://claude.ai/code/session_012hCo82mqoQ9ktERvz1kJQq)_