### PR TITLE
Add worktrunk config to copy ignored files into new worktrees

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,9 @@
+# Worktrunk project config — https://worktrunk.dev
+#
+# When a new worktree is created, copy this repo's gitignored/untracked files
+# (node_modules, vendor, .env, build caches, …) into it so the worktree is
+# ready to run without a fresh `composer install` / `npm install`.
+#
+# post-start runs in the background after the worktree is created. `.worktrees/`
+# and VCS/tool-state dirs are excluded automatically.
+post-start = "wt step copy-ignored"


### PR DESCRIPTION
## What

Adds `.config/wt.toml`, a [worktrunk](https://worktrunk.dev) project config, with a `post-start` hook that runs `wt step copy-ignored` when a new worktree is created.

## Why

Git worktrees share tracked files but not untracked/gitignored ones. This hook copies gitignored files (`node_modules`, `vendor`, `.env`, build caches, …) from the source worktree into a newly created one, so a fresh worktree is ready to run without another `composer install` / `npm install`. `.worktrees/` and VCS/tool-state dirs are excluded automatically.

Applies to anyone creating worktrees with `wt`/`wtt`. Project-config hooks require a one-time local approval prompt on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)