### PR TITLE
Manage Postgres views as versioned SQL files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,28 @@ public function down(): void
 
 Never edit a version file that has already shipped — migrations reference it by version, so rewriting it changes what `down()` restores.
 
+A new version arrives in a PR as a whole new file, so review it by diffing against the version it replaces:
+
+```bash
+git diff --no-index database/views/media_tracking_summary/v1.sql database/views/media_tracking_summary/v2.sql
+```
+
+#### Views block some table migrations
+
+Postgres refuses to `DROP COLUMN` or `ALTER COLUMN ... TYPE` on a column a view selects. A migration that needs to do either must drop the view first and reapply it afterwards:
+
+```php
+DatabaseView::drop('media_tracking_summary');
+Schema::table('media', function (Blueprint $table) {
+    $table->dropColumn('note');
+});
+DatabaseView::apply('media_tracking_summary', 'v3');
+```
+
+Because the view is created by a migration, a fresh database has it in exactly the same state production does at every point in history — so a migration that trips this fails in CI rather than only in production.
+
+Renames are the quiet case: `RENAME COLUMN` and `RENAME TABLE` succeed, and Postgres silently rewrites the stored view to follow them (`note` becomes `remark AS note`). The live view and its `.sql` file then disagree until the next version is applied.
+
 ## Commands
 
 - Use `ripgrep` to search files and `fd` to find files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,26 @@ e.g. PR #155 -> `https://davidhartingdotcom-web-pr-155.onrender.com`. Preview en
 
 A public, unauthenticated, read-only MCP server is served at `https://davidharting.com/mcp` (`Mcp::web()` in `routes/ai.php`, server and tools in `app/Mcp/`). It exposes published notes and the media library — only information a logged-out visitor can already see. Verify manually with `php artisan mcp:inspector mcp`. See `docs/projects/mcp-server.md`.
 
+### Database views
+
+Postgres view definitions live as versioned SQL files at `database/views/{view}/{version}.sql`, holding only the `SELECT` body. `App\Support\DatabaseView::apply()` drops and recreates the view from one of those files.
+
+To change a view: add the next version file, then a migration that applies the new version on `up()` and the previous one on `down()`.
+
+```php
+public function up(): void
+{
+    DatabaseView::apply('media_tracking_summary', 'v2');
+}
+
+public function down(): void
+{
+    DatabaseView::apply('media_tracking_summary', 'v1');
+}
+```
+
+Never edit a version file that has already shipped — migrations reference it by version, so rewriting it changes what `down()` restores.
+
 ## Commands
 
 - Use `ripgrep` to search files and `fd` to find files

--- a/app/Support/DatabaseView.php
+++ b/app/Support/DatabaseView.php
@@ -28,8 +28,20 @@ class DatabaseView
     {
         $select = self::definition($view, $version);
 
-        DB::statement("DROP VIEW IF EXISTS {$view}");
+        self::drop($view);
         DB::statement("CREATE VIEW {$view} AS {$select}");
+    }
+
+    /**
+     * Drop a view.
+     *
+     * Postgres refuses to `DROP COLUMN` or `ALTER COLUMN ... TYPE` on a column a
+     * view selects, so a migration doing either must drop the view first and
+     * reapply the next version afterwards.
+     */
+    public static function drop(string $view): void
+    {
+        DB::statement("DROP VIEW IF EXISTS {$view}");
     }
 
     /**

--- a/app/Support/DatabaseView.php
+++ b/app/Support/DatabaseView.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+/**
+ * Applies Postgres view definitions that live as versioned `.sql` files under
+ * `database/views/{view}/{version}.sql`.
+ *
+ * Each file holds only the `SELECT` body — this class owns the view name, so a
+ * file can never disagree with the view it defines. Changing a view means
+ * adding the next version file and a migration that applies it on `up()` and
+ * the previous version on `down()`, which keeps the diff to readable SQL
+ * instead of a heredoc pasted into a migration.
+ */
+class DatabaseView
+{
+    /**
+     * (Re)create a view from its versioned definition file.
+     *
+     * Drops and recreates rather than `CREATE OR REPLACE`, which in Postgres
+     * cannot rename, reorder, or retype existing columns — a restriction that
+     * would otherwise make rolling back to an earlier version fail.
+     */
+    public static function apply(string $view, string $version): void
+    {
+        $select = self::definition($view, $version);
+
+        DB::statement("DROP VIEW IF EXISTS {$view}");
+        DB::statement("CREATE VIEW {$view} AS {$select}");
+    }
+
+    /**
+     * Read the `SELECT` body for one version of a view.
+     */
+    public static function definition(string $view, string $version): string
+    {
+        $path = self::path($view, $version);
+
+        if (! is_file($path)) {
+            throw new RuntimeException("No definition for view [{$view}] version [{$version}] at [{$path}].");
+        }
+
+        $select = trim((string) file_get_contents($path));
+
+        if ($select === '') {
+            throw new RuntimeException("Definition for view [{$view}] version [{$version}] is empty.");
+        }
+
+        return rtrim($select, ';');
+    }
+
+    public static function path(string $view, string $version): string
+    {
+        return database_path("views/{$view}/{$version}.sql");
+    }
+}

--- a/database/migrations/2026_08_08_120000_manage_media_tracking_summary_view_from_sql_files.php
+++ b/database/migrations/2026_08_08_120000_manage_media_tracking_summary_view_from_sql_files.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Support\DatabaseView;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Move media_tracking_summary onto versioned `.sql` definition files.
+ *
+ * v1 is the definition the two preceding view migrations already left in the
+ * database, so this is a no-op in behaviour — it exists to make the file the
+ * source of truth from here on.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DatabaseView::apply('media_tracking_summary', 'v1');
+    }
+
+    public function down(): void
+    {
+        DatabaseView::apply('media_tracking_summary', 'v1');
+    }
+};

--- a/database/views/media_tracking_summary/v1.sql
+++ b/database/views/media_tracking_summary/v1.sql
@@ -1,0 +1,40 @@
+-- One row per media item: its identity plus its derived tracking state.
+--
+-- current_status is the most recent non-comment event ('comment' events are
+-- annotations, not state changes), defaulting to 'backlog' when an item has no
+-- events at all.
+SELECT
+    m.id        AS media_id,
+    m.title,
+    m.year,
+    mt.name     AS media_type,
+    c.name      AS creator,
+    COALESCE(
+        (
+            SELECT met.name
+            FROM media_events me
+            JOIN media_event_types met ON me.media_event_type_id = met.id
+            WHERE me.media_id = m.id
+              AND met.name != 'comment'
+            ORDER BY me.occurred_at DESC
+            LIMIT 1
+        ),
+        'backlog'
+    )           AS current_status,
+    agg.started_at,
+    agg.finished_at,
+    agg.abandoned_at,
+    m.creator_id
+FROM media m
+LEFT JOIN media_types mt ON m.media_type_id = mt.id
+LEFT JOIN creators c ON m.creator_id = c.id
+LEFT JOIN LATERAL (
+    SELECT
+        -- ASC: we want the earliest start date, not the most recent restart
+        MIN(me.occurred_at) FILTER (WHERE met.name = 'started')   AS started_at,
+        MAX(me.occurred_at) FILTER (WHERE met.name = 'finished')  AS finished_at,
+        MAX(me.occurred_at) FILTER (WHERE met.name = 'abandoned') AS abandoned_at
+    FROM media_events me
+    JOIN media_event_types met ON me.media_event_type_id = met.id
+    WHERE me.media_id = m.id
+) agg ON TRUE

--- a/tests/Feature/Support/DatabaseViewTest.php
+++ b/tests/Feature/Support/DatabaseViewTest.php
@@ -18,6 +18,27 @@ describe('definition()', function () {
     });
 });
 
+describe('drop()', function () {
+    test('removes the view so blocked table changes can proceed', function () {
+        /** @var TestCase $this */
+        DatabaseView::drop('media_tracking_summary');
+
+        $exists = DB::selectOne(
+            "SELECT 1 AS found FROM pg_views WHERE viewname = 'media_tracking_summary'"
+        );
+
+        $this->assertNull($exists);
+    });
+
+    test('is a no-op when the view does not exist', function () {
+        /** @var TestCase $this */
+        DatabaseView::drop('media_tracking_summary');
+        DatabaseView::drop('media_tracking_summary');
+
+        $this->assertTrue(true);
+    });
+});
+
 describe('apply()', function () {
     test('recreates the view from its definition file', function () {
         /** @var TestCase $this */

--- a/tests/Feature/Support/DatabaseViewTest.php
+++ b/tests/Feature/Support/DatabaseViewTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Support\DatabaseView;
+use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\Support\Facades\DB;
+
+describe('definition()', function () {
+    test('reads the select body from the versioned file', function () {
+        $select = DatabaseView::definition('media_tracking_summary', 'v1');
+
+        expect($select)->toContain('FROM media m');
+        expect($select)->not->toEndWith(';');
+    });
+
+    test('throws when the version file does not exist', function () {
+        expect(fn () => DatabaseView::definition('media_tracking_summary', 'v999'))
+            ->toThrow(RuntimeException::class, 'v999');
+    });
+});
+
+describe('apply()', function () {
+    test('recreates the view from its definition file', function () {
+        /** @var TestCase $this */
+        DB::statement('DROP VIEW IF EXISTS media_tracking_summary');
+
+        DatabaseView::apply('media_tracking_summary', 'v1');
+
+        $exists = DB::selectOne(
+            "SELECT 1 AS found FROM pg_views WHERE viewname = 'media_tracking_summary'"
+        );
+
+        $this->assertNotNull($exists);
+    });
+
+    test('replaces a view whose columns changed shape', function () {
+        /** @var TestCase $this */
+        DB::statement('DROP VIEW IF EXISTS media_tracking_summary');
+        DB::statement('CREATE VIEW media_tracking_summary AS SELECT 1 AS something_else');
+
+        DatabaseView::apply('media_tracking_summary', 'v1');
+
+        $columns = DB::table('information_schema.columns')
+            ->where('table_name', 'media_tracking_summary')
+            ->pluck('column_name');
+
+        $this->assertContains('media_id', $columns->all());
+        $this->assertNotContains('something_else', $columns->all());
+    });
+});


### PR DESCRIPTION
Base of a two-PR stack. Follow-up: `private_notes` column on `media_tracking_summary`.

## Problem

Every tweak to `media_tracking_summary` has meant a new migration carrying a full `CREATE VIEW` heredoc, plus a second copy of the previous definition in `down()`. The SQL is the interesting part and it was buried in PHP string literals, so diffs between versions were unreadable.

## Approach

View definitions now live at `database/views/{view}/{version}.sql`, holding only the `SELECT` body. `App\Support\DatabaseView::apply()` owns the view name — a file can never disagree with the view it defines.

Changing a view becomes: add the next version file, add a migration that applies the new version on `up()` and the previous on `down()`.

```php
public function up(): void
{
    DatabaseView::apply('media_tracking_summary', 'v2');
}

public function down(): void
{
    DatabaseView::apply('media_tracking_summary', 'v1');
}
```

This is the [Scenic](https://github.com/scenic-views/scenic) pattern (`db/views/x_v01.sql` + `update_view ... revert_to_version:`), which is the established answer in this space.

`apply()` does `DROP` + `CREATE` rather than `CREATE OR REPLACE`, because Postgres cannot rename, reorder, or retype existing columns in a replace — which would make rolling back to an earlier version fail.

## Reviewing a view change

A new version lands as a whole new file, so GitHub shows full contents and no diff. Diff the two versions directly:

```bash
git diff --no-index database/views/media_tracking_summary/v1.sql database/views/media_tracking_summary/v2.sql
```

Documented in `CLAUDE.md` alongside the rest.

## Views block some table DDL

Verified against Postgres 16:

| DDL on a column a view selects | Result |
| --- | --- |
| `DROP COLUMN` | blocked — "other objects depend on it" |
| `ALTER COLUMN TYPE` | blocked — "cannot alter type of a column used by a view" |
| `RENAME COLUMN` | allowed — view silently rewrites itself to `remark AS note` |
| `RENAME TABLE` | allowed — view silently repoints |
| `ADD COLUMN` | fine |

`DatabaseView::drop()` is the escape hatch for the first two: drop the view, alter the table, apply the next version. Because the view is created by a migration, a fresh database holds the same view state production does at every point in history, so a migration that trips this fails in CI rather than only on deploy.

The renames are the quiet case — Postgres keeps the view working by rewriting it, leaving the live view and its `.sql` file disagreeing until the next version is applied.

## Notes

- `v1` is byte-for-byte the definition the two earlier view migrations already left in the database, so the migration here is a behavioural no-op.
- Those earlier migrations are untouched — already applied in production, and rewriting them would only risk drift.

## Testing

`tests/Feature/Support/DatabaseViewTest.php` covers reading a definition, the error on a missing version, recreating the view, replacing a view whose columns changed shape, and `drop()`.

Full suite: 381 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxejEmSTVERweRBU8L5ycj)_